### PR TITLE
AL-193249: Add JWT based service account Auth

### DIFF
--- a/python/core-sdk/README.md
+++ b/python/core-sdk/README.md
@@ -27,17 +27,30 @@ To use the SDK, you'll need:
 ## Quick Start
 
 ```python
-from alation_ai_agent_sdk import AlationAIAgentSDK
+from alation_ai_agent_sdk import AlationAIAgentSDK, UserAccountAuthParams, ServiceAccountAuthParams
 
-# Initialize the SDK with your credentials
-sdk = AlationAIAgentSDK(
+# Initialize the SDK using user account authentication
+sdk_user_account = AlationAIAgentSDK(
     base_url="https://your-alation-instance.com",
-    user_id=12345,
-    refresh_token="your-refresh-token"
+    auth_method="user_account",
+    auth_params=UserAccountAuthParams(
+        user_id=12345,
+        refresh_token="your-refresh-token"
+    )
+)
+
+# Initialize the SDK using service account authentication
+sdk_service_account = AlationAIAgentSDK(
+    base_url="https://your-alation-instance.com",
+    auth_method="service_account",
+    auth_params=ServiceAccountAuthParams(
+        client_id="your-client-id",
+        client_secret="your-client-secret"
+    )
 )
 
 # Ask a question about your data
-response = sdk.get_context(
+response = sdk_user_account.get_context(
     "What tables contain sales information?"
 )
 print(response)
@@ -46,10 +59,10 @@ print(response)
 signature = {
     "table": {
         "fields_required": ["name", "title", "description"]
-        }
     }
+}
 
-response = sdk.get_context(
+response = sdk_user_account.get_context(
     "What are the customer tables?",
     signature
 )

--- a/python/core-sdk/alation_ai_agent_sdk/__init__.py
+++ b/python/core-sdk/alation_ai_agent_sdk/__init__.py
@@ -1,3 +1,4 @@
 from .sdk import AlationAIAgentSDK
+from .api import AlationAPI, AlationAPIError, UserAccountAuthParams, ServiceAccountAuthParams
 
 __all__ = ["AlationAIAgentSDK"]

--- a/python/core-sdk/alation_ai_agent_sdk/api.py
+++ b/python/core-sdk/alation_ai_agent_sdk/api.py
@@ -135,13 +135,13 @@ class AlationAPI:
     and provides methods to retrieve context-specific information from the Alation catalog.
 
     Attributes:
-    base_url (str): Base URL for the Alation instance
-    user_id (int): Numeric ID of the Alation user
-    refresh_token (str): Refresh token for API authentication
-    access_token (str, optional): Current API access token
-    client_id (str, optional): id from the OAuth Client Application
-    client_secret (str, optional): secret from OAuth Client Application
-    token_expiry (int): Timestamp for token expiration (Unix timestamp)
+        base_url (str): Base URL for the Alation instance
+        user_id (int): Numeric ID of the Alation user
+        refresh_token (str): Refresh token for API authentication
+        access_token (str, optional): Current API access token
+        client_id (str, optional): id from the OAuth Client Application
+        client_secret (str, optional): secret from OAuth Client Application
+        token_expiry (int): Timestamp for token expiration (Unix timestamp)
     """
 
     def __init__(
@@ -170,7 +170,7 @@ class AlationAPI:
             raise ValueError(
                 "Either (user_id and refresh_token) or (client_id and client_secret) must be provided."
             )
-        logging.debug(f"AlationAPI initialized with auth method: {self.auth_method}")
+        logger.debug(f"AlationAPI initialized with auth method: {self.auth_method}")
 
     def _generate_access_token_with_refresh_token(self):
         """
@@ -182,7 +182,7 @@ class AlationAPI:
             "user_id": self.user_id,
             "refresh_token": self.refresh_token,
         }
-        logging.debug(f"Generating access token using refresh token for user_id: {self.user_id}")
+        logger.debug(f"Generating access token using refresh token for user_id: {self.user_id}")
 
         try:
             response = requests.post(url, json=payload)
@@ -235,7 +235,7 @@ class AlationAPI:
         )
 
         self.token_expiry = expires_at.timestamp()
-        logging.debug(f"Access token generated from refresh token")
+        logger.debug(f"Access token generated from refresh token")
 
     def _generate_jwt_token(self):
         """
@@ -252,7 +252,7 @@ class AlationAPI:
             "accept": "application/json",
             "content-type": "application/x-www-form-urlencoded",
         }
-        logging.debug(f"Generating JWT token")
+        logger.debug(f"Generating JWT token")
         try:
             response = requests.post(url, data=payload, headers=headers)
             response.raise_for_status()
@@ -299,17 +299,17 @@ class AlationAPI:
         self.access_token = data["access_token"]
         expires_in_seconds = int(data["expires_in"])
         self.token_expiry = time.time() + expires_in_seconds
-        logging.debug(f"JWT token generated from client ID and secret")
+        logger.debug(f"JWT token generated from client ID and secret")
 
     def _ensure_token_is_valid(self):
         """
         Ensures a valid access token is available, generating one if needed.
         """
         if self.access_token is not None and time.time() < (self.token_expiry - 60):
-            logging.debug("Access token is still valid.")
+            logger.debug("Access token is still valid.")
             return
 
-        logging.info("Access token is invalid or expired. Attempting to generate a new one.")
+        logger.info("Access token is invalid or expired. Attempting to generate a new one.")
         if self.auth_method == AUTH_METHOD_REFRESH_TOKEN:
             self._generate_access_token_with_refresh_token()
         elif self.auth_method == AUTH_METHOD_SERVICE_ACCOUNT:

--- a/python/core-sdk/alation_ai_agent_sdk/api.py
+++ b/python/core-sdk/alation_ai_agent_sdk/api.py
@@ -5,7 +5,6 @@ from typing import Dict, Any, Optional
 from http import HTTPStatus
 import requests
 
-# Constants for authentication methods
 AUTH_METHOD_REFRESH_TOKEN = "refresh_token"
 AUTH_METHOD_SERVICE_ACCOUNT = "service_account"
 
@@ -156,7 +155,7 @@ class AlationAPI:
         client_id: Optional[str] = None,
         client_secret: Optional[str] = None,
     ):
-        self.base_url = base_url.rstrip("/")  # Ensure no trailing slash
+        self.base_url = base_url.rstrip("/")
         self.access_token: Optional[str] = None
 
         if user_id is not None and refresh_token is not None:
@@ -301,8 +300,11 @@ class AlationAPI:
             )
 
     def _is_access_token_valid(self) -> bool:
-        # 200 if valid
-        # 401 if invalid or revoked
+        """
+        Check if the access token is valid by making a request to the validation endpoint.
+        Returns True if valid, False if invalid or revoked.
+
+        """
 
         url = f"{self.base_url}/integration/v1/validateAPIAccessToken/"
         payload = {"api_access_token": self.access_token, "user_id": self.user_id}

--- a/python/core-sdk/alation_ai_agent_sdk/api.py
+++ b/python/core-sdk/alation_ai_agent_sdk/api.py
@@ -65,8 +65,9 @@ class AlationErrorClassifier:
                 or "Request was malformed. Check the query and signature structure."
             )
             help_links = [
-                "https://github.com/Alation/ai-agent-sdk/blob/main/guides/signature.md",
-                "https://github.com/Alation/ai-agent-sdk/blob/main/README.md",
+                "https://github.com/Alation/alation-ai-agent-sdk/blob/main/guides/signature.md",
+                "https://github.com/Alation/alation-ai-agent-sdk?tab=readme-ov-file#usage",
+                "https://developer.alation.com/dev/docs/customize-the-aggregated-context-api-calls-with-a-signature",
             ]
         elif status_code == HTTPStatus.UNAUTHORIZED:
             reason = "Unauthorized"
@@ -89,15 +90,21 @@ class AlationErrorClassifier:
             resolution_hint = (
                 "The requested resource was not found or is not enabled, check feature flag"
             )
-            help_links = ["https://developer.alation.com/"]
+            help_links = [
+                "https://developer.alation.com/dev/docs/guide-to-aggregated-context-api-beta"
+            ]
         elif status_code == HTTPStatus.TOO_MANY_REQUESTS:
             reason = "Too Many Requests"
             resolution_hint = "Rate limit exceeded. Retry after some time."
-            help_links = ["https://developer.alation.com/dev/docs/api-throttling"]
+            help_links = [
+                "https://developer.alation.com/dev/docs/guide-to-aggregated-context-api-beta#rate-limiting"
+            ]
         elif status_code == HTTPStatus.INTERNAL_SERVER_ERROR:
             reason = "Internal Server Error"
             resolution_hint = "Server error. Retry later or contact Alation support."
-            help_links = ["https://developer.alation.com/", "https://docs.alation.com/en/latest/"]
+            help_links = [
+                "https://developer.alation.com/dev/docs/guide-to-aggregated-context-api-beta"
+            ]
 
         return {"reason": reason, "resolution_hint": resolution_hint, "help_links": help_links}
 

--- a/python/core-sdk/alation_ai_agent_sdk/api.py
+++ b/python/core-sdk/alation_ai_agent_sdk/api.py
@@ -133,6 +133,15 @@ class AlationAPI:
     Client for interacting with the Alation API.
     This class manages authentication (via refresh token or service account)
     and provides methods to retrieve context-specific information from the Alation catalog.
+
+    Attributes:
+    base_url (str): Base URL for the Alation instance
+    user_id (int): Numeric ID of the Alation user
+    refresh_token (str): Refresh token for API authentication
+    access_token (str, optional): Current API access token
+    client_id (str, optional): id from the OAuth Client Application
+    client_secret (str, optional): secret from OAuth Client Application
+    token_expiry (int): Timestamp for token expiration (Unix timestamp)
     """
 
     def __init__(

--- a/python/core-sdk/alation_ai_agent_sdk/sdk.py
+++ b/python/core-sdk/alation_ai_agent_sdk/sdk.py
@@ -10,53 +10,28 @@ class AlationAIAgentSDK:
     SDK for interacting with Alation AI Agent capabilities.
 
     Can be initialized using one of two authentication methods:
-    1. User ID and Refresh Token:
-       sdk = AlationAIAgentSDK(base_url="https://company.alationcloud.com", user_id=123, refresh_token="your_refresh_token")
-    2. Service Account (Client ID and Client Secret):
-       sdk = AlationAIAgentSDK(base_url="https://company.alationcloud.com", client_id="your_client_id", client_secret="your_client_secret")
-
-    If both sets of credentials are provided, Client ID and Client Secret will be used by default.
+    1. Refresh Token Authentication:
+       sdk = AlationAIAgentSDK(base_url="https://company.alationcloud.com", auth_method="refresh_token", auth_params=(123, "your_refresh_token"))
+    2. Service Account Authentication:
+       sdk = AlationAIAgentSDK(base_url="https://company.alationcloud.com", auth_method="service_account", auth_params=("your_client_id", "your_client_secret"))
     """
 
     def __init__(
         self,
         base_url: str,
-        user_id: Optional[int] = None,
-        refresh_token: Optional[str] = None,
-        client_id: Optional[str] = None,
-        client_secret: Optional[str] = None,
+        auth_method: str,
+        auth_params: tuple,
     ):
         if not base_url or not isinstance(base_url, str):
             raise ValueError("base_url must be a non-empty string.")
 
-        # Determine authentication method, prioritizing service account if both are provided
-        is_service_account_auth = client_id is not None and client_secret is not None
-        is_refresh_token_auth = user_id is not None and refresh_token is not None
+        if not auth_method or not isinstance(auth_method, str):
+            raise ValueError("auth_method must be a non-empty string.")
 
-        if is_service_account_auth:
-            # Use service account credentials
-            if not client_id or not isinstance(client_id, str):
-                raise ValueError(
-                    "client_id must be a non-empty string for service account authentication."
-                )
-            if not client_secret or not isinstance(client_secret, str):
-                raise ValueError(
-                    "client_secret must be a non-empty string for service account authentication."
-                )
-            self.auth_params = {"client_id": client_id, "client_secret": client_secret}
+        if not isinstance(auth_params, tuple):
+            raise ValueError("auth_params must be a tuple.")
 
-        elif is_refresh_token_auth:
-            if not isinstance(user_id, int):
-                raise ValueError("user_id must be an integer for refresh token authentication.")
-            if not refresh_token or not isinstance(refresh_token, str):
-                raise ValueError("refresh_token must be a non-empty string")
-            self.auth_params = {"user_id": user_id, "refresh_token": refresh_token}
-        else:
-            raise ValueError(
-                "Missing authentication credentials. Provide either (user_id and refresh_token) or (client_id and client_secret)."
-            )
-
-        self.api = AlationAPI(base_url=base_url, **self.auth_params)
+        self.api = AlationAPI(base_url=base_url, auth_method=auth_method, auth_params=auth_params)
         self.context_tool = AlationContextTool(self.api)
 
     def get_context(

--- a/python/core-sdk/alation_ai_agent_sdk/sdk.py
+++ b/python/core-sdk/alation_ai_agent_sdk/sdk.py
@@ -1,7 +1,10 @@
 from typing import Dict, Any, Optional
-from http import HTTPStatus  # Added for HTTPStatus.BAD_REQUEST
 
-from .api import AlationAPI, AlationAPIError
+from .api import (
+    AlationAPI,
+    AlationAPIError,
+    AuthParams,
+)
 from .tools import AlationContextTool
 
 
@@ -10,8 +13,8 @@ class AlationAIAgentSDK:
     SDK for interacting with Alation AI Agent capabilities.
 
     Can be initialized using one of two authentication methods:
-    1. Refresh Token Authentication:
-       sdk = AlationAIAgentSDK(base_url="https://company.alationcloud.com", auth_method="refresh_token", auth_params=(123, "your_refresh_token"))
+    1. User Account Authentication:
+       sdk = AlationAIAgentSDK(base_url="https://company.alationcloud.com", auth_method="user_account", auth_params=(123, "your_refresh_token"))
     2. Service Account Authentication:
        sdk = AlationAIAgentSDK(base_url="https://company.alationcloud.com", auth_method="service_account", auth_params=("your_client_id", "your_client_secret"))
     """
@@ -20,7 +23,7 @@ class AlationAIAgentSDK:
         self,
         base_url: str,
         auth_method: str,
-        auth_params: tuple,
+        auth_params: AuthParams,
     ):
         if not base_url or not isinstance(base_url, str):
             raise ValueError("base_url must be a non-empty string.")
@@ -28,9 +31,7 @@ class AlationAIAgentSDK:
         if not auth_method or not isinstance(auth_method, str):
             raise ValueError("auth_method must be a non-empty string.")
 
-        if not isinstance(auth_params, tuple):
-            raise ValueError("auth_params must be a tuple.")
-
+        # Delegate validation of auth_params to AlationAPI
         self.api = AlationAPI(base_url=base_url, auth_method=auth_method, auth_params=auth_params)
         self.context_tool = AlationContextTool(self.api)
 

--- a/python/core-sdk/alation_ai_agent_sdk/sdk.py
+++ b/python/core-sdk/alation_ai_agent_sdk/sdk.py
@@ -1,19 +1,63 @@
 from typing import Dict, Any, Optional
+from http import HTTPStatus  # Added for HTTPStatus.BAD_REQUEST
 
 from .api import AlationAPI, AlationAPIError
 from .tools import AlationContextTool
 
 
 class AlationAIAgentSDK:
-    def __init__(self, base_url: str, user_id: int, refresh_token: str):
+    """
+    SDK for interacting with Alation AI Agent capabilities.
+
+    Can be initialized using one of two authentication methods:
+    1. User ID and Refresh Token:
+       sdk = AlationAIAgentSDK(base_url="https://company.alationcloud.com", user_id=123, refresh_token="your_refresh_token")
+    2. Service Account (Client ID and Client Secret):
+       sdk = AlationAIAgentSDK(base_url="https://company.alationcloud.com", client_id="your_client_id", client_secret="your_client_secret")
+
+    If both sets of credentials are provided, Client ID and Client Secret will be used by default.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        user_id: Optional[int] = None,
+        refresh_token: Optional[str] = None,
+        client_id: Optional[str] = None,
+        client_secret: Optional[str] = None,
+    ):
         if not base_url or not isinstance(base_url, str):
             raise ValueError("base_url must be a non-empty string.")
-        if not isinstance(user_id, int):
-            raise ValueError("user_id must be an integer.")
-        if not refresh_token or not isinstance(refresh_token, str):
-            raise ValueError("refresh_token must be a non-empty string.")
 
-        self.api = AlationAPI(base_url, user_id, refresh_token)
+        # Determine authentication method, prioritizing service account if both are provided
+        is_service_account_auth = client_id is not None and client_secret is not None
+        is_refresh_token_auth = user_id is not None and refresh_token is not None
+
+        if is_service_account_auth:
+            # Use service account credentials
+            if not client_id or not isinstance(client_id, str):
+                raise ValueError(
+                    "client_id must be a non-empty string for service account authentication."
+                )
+            if not client_secret or not isinstance(client_secret, str):
+                raise ValueError(
+                    "client_secret must be a non-empty string for service account authentication."
+                )
+            self.auth_params = {"client_id": client_id, "client_secret": client_secret}
+            if is_refresh_token_auth:
+                pass
+        elif is_refresh_token_auth:
+            if not isinstance(user_id, int):
+                raise ValueError("user_id must be an integer for refresh token authentication.")
+            if not refresh_token or not isinstance(refresh_token, str):
+                raise ValueError("refresh_token must be a non-empty string")
+            self.auth_params = {"user_id": user_id, "refresh_token": refresh_token}
+        else:
+            raise ValueError(
+                "Missing authentication credentials. Provide either (user_id and refresh_token) or (client_id and client_secret)."
+            )
+
+        self.api = AlationAPI(base_url=base_url, **self.auth_params)
         self.context_tool = AlationContextTool(self.api)
 
     def get_context(

--- a/python/core-sdk/alation_ai_agent_sdk/sdk.py
+++ b/python/core-sdk/alation_ai_agent_sdk/sdk.py
@@ -44,8 +44,7 @@ class AlationAIAgentSDK:
                     "client_secret must be a non-empty string for service account authentication."
                 )
             self.auth_params = {"client_id": client_id, "client_secret": client_secret}
-            if is_refresh_token_auth:
-                pass
+
         elif is_refresh_token_auth:
             if not isinstance(user_id, int):
                 raise ValueError("user_id must be an integer for refresh token authentication.")

--- a/python/core-sdk/pyproject.toml
+++ b/python/core-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "alation-ai-agent-sdk"
-version = "0.2.0"
+version = "0.2.1"
 description = "Alation Agent SDK"
 authors = [
   { name="Jagannath (Jags) Saragadam", email="jags.saragadam@alation.com"},

--- a/python/core-sdk/tests/test_sdk.py
+++ b/python/core-sdk/tests/test_sdk.py
@@ -11,7 +11,7 @@ from alation_ai_agent_sdk.api import (
 
 
 # --- Mock API Responses & Constants ---
-MOCK_BASE_URL = "https://fake-alation-instance.com"
+MOCK_BASE_URL = "https://mock-alation-instance.com"
 MOCK_USER_ID = 123
 MOCK_REFRESH_TOKEN = "test-refresh-token"
 MOCK_CLIENT_ID = "test-client-id"

--- a/python/core-sdk/tests/test_sdk.py
+++ b/python/core-sdk/tests/test_sdk.py
@@ -1,44 +1,281 @@
 import pytest
 import requests
+from datetime import datetime, timezone, timedelta
+from unittest.mock import MagicMock, patch
 
-from alation_ai_agent_sdk import AlationAIAgentSDK
+from alation_ai_agent_sdk.sdk import AlationAIAgentSDK
+from alation_ai_agent_sdk.api import (
+    AUTH_METHOD_REFRESH_TOKEN,
+    AUTH_METHOD_SERVICE_ACCOUNT,
+)
+
+
+# --- Mock API Responses & Constants ---
+MOCK_BASE_URL = "https://fake-alation-instance.com"
+MOCK_USER_ID = 123
+MOCK_REFRESH_TOKEN = "test-refresh-token"
+MOCK_CLIENT_ID = "test-client-id"
+MOCK_CLIENT_SECRET = "test-client-secret"
+
+REFRESH_TOKEN_EXPIRES_AT = (
+    (datetime.now(timezone.utc) + timedelta(hours=24)).isoformat().replace("+00:00", "Z")
+)
+
+REFRESH_TOKEN_RESPONSE_SUCCESS = {
+    "api_access_token": "mock-api-access-token-from-refresh",
+    "status": "success",
+    "user_id": MOCK_USER_ID,
+    "created_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    "token_expires_at": REFRESH_TOKEN_EXPIRES_AT,
+    "token_status": "ACTIVE",
+}
+
+JWT_RESPONSE_SUCCESS = {
+    "access_token": "mock-jwt-access-token",
+    "expires_in": 3600,
+    "token_type": "Bearer",
+}
+
+CONTEXT_RESPONSE_SUCCESS = {"some_context_key": "some_context_value"}
 
 
 @pytest.fixture
 def mock_requests_post(monkeypatch):
-    """Fixture to mock requests"""
+    """Mocks requests.post with a flexible router for different URLs."""
+    mock_post_responses = {}
 
-    def mock_post(*args, **kwargs):
-        class MockResponse:
-            def __init__(self):
-                self.status_code = 200
+    def _add_mock_response(
+        url_identifier,
+        response_json=None,
+        status_code=200,
+        raise_for_status_exception=None,
+        side_effect=None,
+    ):
+        mock_response = MagicMock(spec=requests.Response)
+        mock_response.status_code = status_code
+        if response_json is not None:
+            mock_response.json = MagicMock(return_value=response_json)
+        else:
+            mock_response.json = MagicMock(
+                side_effect=requests.exceptions.JSONDecodeError("No JSON", "doc", 0)
+            )
 
-            def raise_for_status(self):
-                pass
+        if raise_for_status_exception:
+            mock_response.raise_for_status = MagicMock(side_effect=raise_for_status_exception)
+        else:
+            mock_response.raise_for_status = MagicMock()
 
-            def json(self):
-                return {"api_access_token": "mock-token", "status": "success"}
+        if side_effect:
+            mock_post_responses[url_identifier] = MagicMock(side_effect=side_effect)
+        else:
+            mock_post_responses[url_identifier] = MagicMock(return_value=mock_response)
 
-        return MockResponse()
+    def mock_post_router(*args, **kwargs):
+        url = args[0]
 
-    monkeypatch.setattr(requests, "post", mock_post)
+        if "createAPIAccessToken" in url:
+            if "createAPIAccessToken" in mock_post_responses:
+                return mock_post_responses["createAPIAccessToken"](*args, **kwargs)
+        elif "auth/accessToken" in url:
+            if "auth/accessToken" in mock_post_responses:
+                return mock_post_responses["auth/accessToken"](*args, **kwargs)
+
+        # Fallback for unmocked POST requests
+        fallback_response = MagicMock(spec=requests.Response)
+        fallback_response.status_code = 404
+        fallback_response.json = MagicMock(return_value={"error": "Not Found - Unmocked POST URL"})
+        fallback_response.raise_for_status = MagicMock(
+            side_effect=requests.exceptions.HTTPError("404 Not Found")
+        )
+        return fallback_response
+
+    monkeypatch.setattr(requests, "post", mock_post_router)
+    return _add_mock_response
+
+
+@pytest.fixture
+def mock_requests_get(monkeypatch):
+    """Mocks requests.get for context API calls."""
+    mock_get_responses = {}
+
+    def _add_mock_response(
+        url_identifier,
+        response_json=None,
+        status_code=200,
+        raise_for_status_exception=None,
+        side_effect=None,
+    ):
+        mock_response = MagicMock(spec=requests.Response)
+        mock_response.status_code = status_code
+        if response_json is not None:
+            mock_response.json = MagicMock(return_value=response_json)
+        else:
+            mock_response.json = MagicMock(
+                side_effect=requests.exceptions.JSONDecodeError("No JSON", "doc", 0)
+            )
+
+        if raise_for_status_exception:
+            mock_response.raise_for_status = MagicMock(side_effect=raise_for_status_exception)
+        else:
+            mock_response.raise_for_status = MagicMock()
+
+        if side_effect:
+            mock_get_responses[url_identifier] = MagicMock(side_effect=side_effect)
+        else:
+            mock_get_responses[url_identifier] = MagicMock(return_value=mock_response)
+
+    def mock_get_router(*args, **kwargs):
+        url = args[0]
+        if "context/" in url:
+            if "context/" in mock_get_responses:
+                return mock_get_responses["context/"](*args, **kwargs)
+
+        # Fallback for unmocked GET requests
+        fallback_response = MagicMock(spec=requests.Response)
+        fallback_response.status_code = 404
+        fallback_response.json = MagicMock(return_value={"error": "Not Found - Unmocked GET URL"})
+        fallback_response.raise_for_status = MagicMock(
+            side_effect=requests.exceptions.HTTPError("404 Not Found")
+        )
+        return fallback_response
+
+    monkeypatch.setattr(requests, "get", mock_get_router)
+    return _add_mock_response
+
+
+# --- SDK Initialization Tests ---
+
+
+def test_sdk_valid_initialization_refresh_token():
+    """Test valid SDK init with user_id and refresh_token."""
+    sdk = AlationAIAgentSDK(
+        base_url=MOCK_BASE_URL, user_id=MOCK_USER_ID, refresh_token=MOCK_REFRESH_TOKEN
+    )
+    assert sdk.api.auth_method == AUTH_METHOD_REFRESH_TOKEN
+    assert sdk.api.user_id == MOCK_USER_ID
+
+
+def test_sdk_valid_initialization_service_account():
+    """Test valid SDK init with client_id and client_secret."""
+    sdk = AlationAIAgentSDK(
+        base_url=MOCK_BASE_URL, client_id=MOCK_CLIENT_ID, client_secret=MOCK_CLIENT_SECRET
+    )
+    assert sdk.api.auth_method == AUTH_METHOD_SERVICE_ACCOUNT
+    assert sdk.api.client_id == MOCK_CLIENT_ID
+
+
+def test_sdk_initialization_service_account_priority():
+    """Test SDK defaults to service account if all credentials provided."""
+    sdk = AlationAIAgentSDK(
+        base_url=MOCK_BASE_URL,
+        user_id=MOCK_USER_ID,
+        refresh_token=MOCK_REFRESH_TOKEN,
+        client_id=MOCK_CLIENT_ID,
+        client_secret=MOCK_CLIENT_SECRET,
+    )
+    assert sdk.api.auth_method == AUTH_METHOD_SERVICE_ACCOUNT
 
 
 @pytest.mark.parametrize(
-    "base_url, user_id, refresh_token",
+    "init_kwargs, expected_error_message_part",
     [
-        (None, 12345, "token"),  # Missing base_url
-        ("", 12345, "token"),  # Empty base_url
-        ("https://valid.url", None, "token"),  # Missing user_id
-        ("https://valid.url", "not-an-integer", "token"),  # Invalid user_id
-        ("https://valid.url", 12345, None),  # Missing refresh_token
-        ("https://valid.url", 12345, ""),  # Empty refresh_token
+        # --- Base URL Validation ---
+        (
+            {"base_url": None, "user_id": MOCK_USER_ID, "refresh_token": MOCK_REFRESH_TOKEN},
+            "base_url must be a non-empty string",
+        ),
+        # --- "Missing authentication credentials" ---
+        # (Neither SA nor RT creds are fully and correctly provided to select an auth path)
+        (
+            {"base_url": MOCK_BASE_URL},  # Only base_url
+            "Missing authentication credentials. Provide either (user_id and refresh_token) or (client_id and client_secret).",
+        ),
+        (  # Incomplete RT (missing refresh_token), no SA
+            {"base_url": MOCK_BASE_URL, "user_id": MOCK_USER_ID},
+            "Missing authentication credentials. Provide either (user_id and refresh_token) or (client_id and client_secret).",
+        ),
+        (  # Incomplete RT (missing user_id), no SA
+            {"base_url": MOCK_BASE_URL, "refresh_token": MOCK_REFRESH_TOKEN},
+            "Missing authentication credentials. Provide either (user_id and refresh_token) or (client_id and client_secret).",
+        ),
+        (  # Incomplete SA (missing client_secret), no RT
+            {"base_url": MOCK_BASE_URL, "client_id": MOCK_CLIENT_ID},
+            "Missing authentication credentials. Provide either (user_id and refresh_token) or (client_id and client_secret).",
+        ),
+        (  # Incomplete SA (missing client_id), no RT
+            {"base_url": MOCK_BASE_URL, "client_secret": MOCK_CLIENT_SECRET},
+            "Missing authentication credentials. Provide either (user_id and refresh_token) or (client_id and client_secret).",
+        ),
+        (  # Both RT and SA creds are individually incomplete
+            {"base_url": MOCK_BASE_URL, "user_id": MOCK_USER_ID, "client_id": MOCK_CLIENT_ID},
+            "Missing authentication credentials. Provide either (user_id and refresh_token) or (client_id and client_secret).",
+        ),
     ],
 )
-def test_sdk_invalid_initialization(base_url, user_id, refresh_token, mock_requests_post):
-    with pytest.raises(ValueError):
-        AlationAIAgentSDK(
-            base_url=base_url,
-            user_id=user_id,
-            refresh_token=refresh_token,
+def test_sdk_invalid_initialization_combinations(init_kwargs, expected_error_message_part):
+    """Test various invalid SDK initialization scenarios."""
+    with pytest.raises(ValueError) as excinfo:
+        AlationAIAgentSDK(**init_kwargs)
+    assert expected_error_message_part in str(excinfo.value)
+
+
+def test_get_context_token_reuse(mock_requests_post, mock_requests_get):
+    """Test that a valid token is reused."""
+    mock_requests_post("createAPIAccessToken", response_json=REFRESH_TOKEN_RESPONSE_SUCCESS)
+    mock_requests_get("context/", response_json=CONTEXT_RESPONSE_SUCCESS)
+    sdk = AlationAIAgentSDK(
+        base_url=MOCK_BASE_URL, user_id=MOCK_USER_ID, refresh_token=MOCK_REFRESH_TOKEN
+    )
+
+    initial_time = (
+        datetime.strptime(REFRESH_TOKEN_EXPIRES_AT, "%Y-%m-%dT%H:%M:%S.%fZ")
+        .replace(tzinfo=timezone.utc)
+        .timestamp()
+        - 1000
+    )
+    time_after_first_call = initial_time + 10
+
+    with patch("time.time") as mock_time:
+        mock_time.return_value = initial_time
+        sdk.get_context("first question")
+
+        with patch.object(
+            sdk.api,
+            "_generate_access_token_with_refresh_token",
+            wraps=sdk.api._generate_access_token_with_refresh_token,
+        ) as spy_gen_token:
+            mock_time.return_value = time_after_first_call
+            sdk.get_context("second question")
+            spy_gen_token.assert_not_called()
+
+
+def test_get_context_token_refresh_on_expiry(mock_requests_post, mock_requests_get):
+    """Test that token is refreshed if expired."""
+    mock_requests_post("createAPIAccessToken", response_json=REFRESH_TOKEN_RESPONSE_SUCCESS)
+    mock_requests_get("context/", response_json=CONTEXT_RESPONSE_SUCCESS)
+    sdk = AlationAIAgentSDK(
+        base_url=MOCK_BASE_URL, user_id=MOCK_USER_ID, refresh_token=MOCK_REFRESH_TOKEN
+    )
+
+    with patch.object(
+        sdk.api,
+        "_generate_access_token_with_refresh_token",
+        wraps=sdk.api._generate_access_token_with_refresh_token,
+    ) as spy_gen_token:
+        time_at_first_gen = (
+            datetime.strptime(REFRESH_TOKEN_EXPIRES_AT, "%Y-%m-%dT%H:%M:%S.%fZ")
+            .replace(tzinfo=timezone.utc)
+            .timestamp()
+            - timedelta(hours=24).total_seconds()
+            - 100
         )
+        with patch("time.time") as mock_time:
+            mock_time.return_value = time_at_first_gen
+            sdk.get_context("first question, generates token")
+            spy_gen_token.assert_called_once()
+
+            time_after_expiry = sdk.api.token_expiry - 50
+            mock_time.return_value = time_after_expiry
+
+            sdk.get_context("second question, should refresh token")
+            assert spy_gen_token.call_count == 2

--- a/python/dist-langchain/README.md
+++ b/python/dist-langchain/README.md
@@ -30,18 +30,31 @@ from langchain_openai import ChatOpenAI
 from langchain.agents import AgentExecutor, create_openai_functions_agent
 from langchain.prompts import ChatPromptTemplate, MessagesPlaceholder
 
-from alation_ai_agent_sdk import AlationAIAgentSDK
+from alation_ai_agent_sdk import AlationAIAgentSDK, UserAccountAuthParams, ServiceAccountAuthParams
 from alation_ai_agent_langchain import get_langchain_tools
 
-# Initialize Alation SDK
-sdk = AlationAIAgentSDK(
+# Initialize Alation SDK using user account authentication
+sdk_user_account = AlationAIAgentSDK(
     base_url=os.getenv("ALATION_BASE_URL"),
-    user_id=int(os.getenv("ALATION_USER_ID")),
-    refresh_token=os.getenv("ALATION_REFRESH_TOKEN")
+    auth_method="user_account",  # Specify the authentication method
+    auth_params=UserAccountAuthParams(
+        user_id=int(os.getenv("ALATION_USER_ID")),
+        refresh_token=os.getenv("ALATION_REFRESH_TOKEN")
+    )
+)
+
+# Initialize Alation SDK using service account authentication
+sdk_service_account = AlationAIAgentSDK(
+    base_url=os.getenv("ALATION_BASE_URL"),
+    auth_method="service_account",  # Specify the authentication method
+    auth_params=ServiceAccountAuthParams(
+        client_id=os.getenv("ALATION_CLIENT_ID"),
+        client_secret=os.getenv("ALATION_CLIENT_SECRET")
+    )
 )
 
 # Get Langchain tools
-tools = get_langchain_tools(sdk)
+tools = get_langchain_tools(sdk_user_account)
 
 # Define agent prompt
 prompt = ChatPromptTemplate.from_messages([

--- a/python/dist-langchain/pdm.lock
+++ b/python/dist-langchain/pdm.lock
@@ -5,14 +5,14 @@
 groups = ["default"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:1962def0f36abd8e8dba318c37388e4a04775d4b35d46246bc8282975135760e"
+content_hash = "sha256:078998e0d51a6a737db60849582d936944de73123539a53bcf75c8d289ea0938"
 
 [[metadata.targets]]
 requires_python = ">=3.10"
 
 [[package]]
 name = "alation-ai-agent-sdk"
-version = "0.2.0"
+version = "0.2.1"
 requires_python = ">=3.10"
 summary = "Alation Agent SDK"
 groups = ["default"]
@@ -20,8 +20,8 @@ dependencies = [
     "requests~=2.32.0",
 ]
 files = [
-    {file = "alation_ai_agent_sdk-0.2.0-py3-none-any.whl", hash = "sha256:09f5352e1e21679b2e59793af88cf7f92da0842569d32db6d8b691bbf590a319"},
-    {file = "alation_ai_agent_sdk-0.2.0.tar.gz", hash = "sha256:57d9fd23222a1c877ab4a51f67d92eff8847be5596a012ac0458d13369cc9bea"},
+    {file = "alation_ai_agent_sdk-0.2.1-py3-none-any.whl", hash = "sha256:ed97d2a879ad7c22345a474819bf94140b21d880e18d47e926cd731495040119"},
+    {file = "alation_ai_agent_sdk-0.2.1.tar.gz", hash = "sha256:f672fc0eb0ea46384233fd6e47726456ae6843539ce680d044b901a23c5f2da8"},
 ]
 
 [[package]]

--- a/python/dist-langchain/pyproject.toml
+++ b/python/dist-langchain/pyproject.toml
@@ -3,7 +3,7 @@ name = "alation-ai-agent-langchain"
 version = "0.2.1"
 description = "Alation Agent SDK for Langchain"
 dependencies = [
-  "alation-ai-agent-sdk~=0.2.1",
+  "alation-ai-agent-sdk>=0.2.1",
   "requests~=2.32.0",
   "langchain>=0.1.0"
 ]

--- a/python/dist-langchain/pyproject.toml
+++ b/python/dist-langchain/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "alation-ai-agent-langchain"
-version = "0.2.0"
+version = "0.2.1"
 description = "Alation Agent SDK for Langchain"
 dependencies = [
-  "alation-ai-agent-sdk~=0.2",
+  "alation-ai-agent-sdk~=0.2.1",
   "requests~=2.32.0",
   "langchain>=0.1.0"
 ]

--- a/python/dist-mcp/README.md
+++ b/python/dist-mcp/README.md
@@ -26,8 +26,14 @@ Set up your environment variables:
 
 ```bash
 export ALATION_BASE_URL="https://your-alation-instance.com"
+export ALATION_AUTH_METHOD="user_account"
 export ALATION_USER_ID="12345"
 export ALATION_REFRESH_TOKEN="your-refresh-token"
+
+# Alternatively, for service account authentication
+export ALATION_AUTH_METHOD="service_account"
+export ALATION_CLIENT_ID="your-client-id"
+export ALATION_CLIENT_SECRET="your-client-secret"
 ```
 
 To run the Alation MCP Server, use [uvx](https://docs.astral.sh/uv/guides/tools/) (recommend), use the following command:

--- a/python/dist-mcp/alation_ai_agent_mcp/server.py
+++ b/python/dist-mcp/alation_ai_agent_mcp/server.py
@@ -2,7 +2,7 @@ import os
 from typing import Dict, Any
 
 from mcp.server.fastmcp import FastMCP
-from alation_ai_agent_sdk import AlationAIAgentSDK
+from alation_ai_agent_sdk import AlationAIAgentSDK, UserAccountAuthParams, ServiceAccountAuthParams
 
 
 def create_server():
@@ -15,19 +15,18 @@ def create_server():
             "Missing required environment variables: ALATION_BASE_URL and ALATION_AUTH_METHOD"
         )
 
-    # Parse raw auth parameters based on auth_method
-    if auth_method == "refresh_token":
+    if auth_method == "user_account":
         user_id = os.getenv("ALATION_USER_ID")
         refresh_token = os.getenv("ALATION_REFRESH_TOKEN")
         if not user_id or not refresh_token:
             raise ValueError(
-                "Missing required environment variables: ALATION_USER_ID and ALATION_REFRESH_TOKEN for 'refresh_token' auth_method"
+                "Missing required environment variables: ALATION_USER_ID and ALATION_REFRESH_TOKEN for 'user_account' auth_method"
             )
         try:
-            user_id = int(user_id)  # Ensure user_id is an integer
+            user_id = int(user_id)
         except ValueError:
             raise ValueError("ALATION_USER_ID must be an integer.")
-        auth_params = (user_id, refresh_token)
+        auth_params = UserAccountAuthParams(user_id, refresh_token)
 
     elif auth_method == "service_account":
         client_id = os.getenv("ALATION_CLIENT_ID")
@@ -36,10 +35,12 @@ def create_server():
             raise ValueError(
                 "Missing required environment variables: ALATION_CLIENT_ID and ALATION_CLIENT_SECRET for 'service_account' auth_method"
             )
-        auth_params = (client_id, client_secret)
+        auth_params = ServiceAccountAuthParams(client_id, client_secret)
 
     else:
-        raise ValueError("Invalid ALATION_AUTH_METHOD. Must be 'refresh_token' or 'service_account'.")
+        raise ValueError(
+            "Invalid ALATION_AUTH_METHOD. Must be 'user_account' or 'service_account'."
+        )
 
     # Initialize FastMCP server
     mcp = FastMCP(name="Alation MCP Server", version="0.1.0")

--- a/python/dist-mcp/alation_ai_agent_mcp/server.py
+++ b/python/dist-mcp/alation_ai_agent_mcp/server.py
@@ -10,10 +10,13 @@ def create_server():
     base_url = os.getenv("ALATION_BASE_URL")
     user_id_raw = os.getenv("ALATION_USER_ID")
     refresh_token = os.getenv("ALATION_REFRESH_TOKEN")
+    client_id = os.getenv("ALATION_CLIENT_ID")
+    client_secret = os.getenv("ALATION_CLIENT_SECRET")
 
-    if not base_url or not user_id_raw or not refresh_token:
+    if not base_url or not ((user_id_raw and refresh_token) or (client_id and client_secret)):
         raise ValueError(
-            "Missing required environment variables: ALATION_BASE_URL, ALATION_USER_ID, ALATION_REFRESH_TOKEN"
+            "Missing required environment variables: ALATION_BASE_URL and either "
+            "(ALATION_USER_ID + ALATION_REFRESH_TOKEN) or (ALATION_CLIENT_ID + ALATION_CLIENT_SECRET)"
         )
 
     user_id = int(user_id_raw)
@@ -22,7 +25,7 @@ def create_server():
     mcp = FastMCP(name="Alation MCP Server", version="0.1.0")
 
     # Initialize Alation SDK
-    alation_sdk = AlationAIAgentSDK(base_url, user_id, refresh_token)
+    alation_sdk = AlationAIAgentSDK(base_url, user_id, refresh_token, client_id, client_secret)
 
     @mcp.tool(name=alation_sdk.context_tool.name, description=alation_sdk.context_tool.description)
     def alation_context(question: str, signature: Dict[str, Any] | None = None) -> str:

--- a/python/dist-mcp/pyproject.toml
+++ b/python/dist-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "alation-ai-agent-mcp"
-version = "0.2.0"
+version = "0.2.1"
 description = "Alation Agent SDK with MCP support"
 dependencies = [
   "alation-ai-agent-sdk~=0.2.1",

--- a/python/dist-mcp/pyproject.toml
+++ b/python/dist-mcp/pyproject.toml
@@ -3,7 +3,7 @@ name = "alation-ai-agent-mcp"
 version = "0.2.0"
 description = "Alation Agent SDK with MCP support"
 dependencies = [
-  "alation-ai-agent-sdk~=0.2",
+  "alation-ai-agent-sdk~=0.2.1",
   "mcp[cli]>=1.2.0",
   "fastMCP>=2.2.6"
 ]

--- a/python/dist-mcp/tests/test_mcp_server.py
+++ b/python/dist-mcp/tests/test_mcp_server.py
@@ -171,3 +171,24 @@ def test_run_server_calls_create_and_run(mock_create_server, mock_fastmcp):
     mock_create_server.assert_called_once()
     mock_mcp_instance.run.assert_called_once()
     assert server.mcp is mock_mcp_instance
+
+
+def test_create_server_service_account(manage_environment_variables, monkeypatch, mock_alation_sdk, mock_fastmcp):
+    """
+    Test successful creation of the server with service_account authentication.
+    """
+    # Set environment variables for service_account auth method
+    monkeypatch.setenv("ALATION_AUTH_METHOD", "service_account")
+    monkeypatch.setenv("ALATION_CLIENT_ID", "mock-client-id")
+    monkeypatch.setenv("ALATION_CLIENT_SECRET", "mock-client-secret")
+
+    mock_sdk_class, mock_sdk_instance = mock_alation_sdk
+    mock_mcp_class, mock_mcp_instance = mock_fastmcp
+
+    mcp_result = server.create_server()
+
+    mock_mcp_class.assert_called_once_with(name="Alation MCP Server", version="0.1.0")
+    mock_sdk_class.assert_called_once_with(
+        "https://mock-alation.com", "service_account", ("mock-client-id", "mock-client-secret")
+    )
+    assert mcp_result is mock_mcp_instance

--- a/python/dist-mcp/tests/test_mcp_server.py
+++ b/python/dist-mcp/tests/test_mcp_server.py
@@ -88,7 +88,9 @@ def test_create_server_success(manage_environment_variables, mock_alation_sdk, m
     mcp_result = server.create_server()
 
     mock_mcp_class.assert_called_once_with(name="Alation MCP Server", version="0.1.0")
-    mock_sdk_class.assert_called_once_with("https://fake-alation.com", 12345, "fake-token")
+    mock_sdk_class.assert_called_once_with(
+        "https://fake-alation.com", 12345, "fake-token", None, None
+    )
     assert mcp_result is mock_mcp_instance
 
 

--- a/python/dist-mcp/tests/test_mcp_server.py
+++ b/python/dist-mcp/tests/test_mcp_server.py
@@ -12,9 +12,9 @@ def manage_environment_variables(monkeypatch):
         "ALATION_USER_ID": os.environ.get("ALATION_USER_ID"),
         "ALATION_REFRESH_TOKEN": os.environ.get("ALATION_REFRESH_TOKEN"),
     }
-    monkeypatch.setenv("ALATION_BASE_URL", "https://fake-alation.com")
+    monkeypatch.setenv("ALATION_BASE_URL", "https://mock-alation.com")
     monkeypatch.setenv("ALATION_USER_ID", "12345")
-    monkeypatch.setenv("ALATION_REFRESH_TOKEN", "fake-token")
+    monkeypatch.setenv("ALATION_REFRESH_TOKEN", "mock-token")
     yield
     for key, value in original_vars.items():
         if value is None:
@@ -89,7 +89,7 @@ def test_create_server_success(manage_environment_variables, mock_alation_sdk, m
 
     mock_mcp_class.assert_called_once_with(name="Alation MCP Server", version="0.1.0")
     mock_sdk_class.assert_called_once_with(
-        "https://fake-alation.com", 12345, "fake-token", None, None
+        "https://mock-alation.com", 12345, "mock-token", None, None
     )
     assert mcp_result is mock_mcp_instance
 

--- a/python/dist-mcp/tests/test_mcp_server.py
+++ b/python/dist-mcp/tests/test_mcp_server.py
@@ -9,10 +9,14 @@ def manage_environment_variables(monkeypatch):
     """Fixture to manage environment variables for tests."""
     original_vars = {
         "ALATION_BASE_URL": os.environ.get("ALATION_BASE_URL"),
+        "ALATION_AUTH_METHOD": os.environ.get("ALATION_AUTH_METHOD"),
         "ALATION_USER_ID": os.environ.get("ALATION_USER_ID"),
         "ALATION_REFRESH_TOKEN": os.environ.get("ALATION_REFRESH_TOKEN"),
+        "ALATION_CLIENT_ID": os.environ.get("ALATION_CLIENT_ID"),
+        "ALATION_CLIENT_SECRET": os.environ.get("ALATION_CLIENT_SECRET"),
     }
     monkeypatch.setenv("ALATION_BASE_URL", "https://mock-alation.com")
+    monkeypatch.setenv("ALATION_AUTH_METHOD", "refresh_token")
     monkeypatch.setenv("ALATION_USER_ID", "12345")
     monkeypatch.setenv("ALATION_REFRESH_TOKEN", "mock-token")
     yield
@@ -89,7 +93,7 @@ def test_create_server_success(manage_environment_variables, mock_alation_sdk, m
 
     mock_mcp_class.assert_called_once_with(name="Alation MCP Server", version="0.1.0")
     mock_sdk_class.assert_called_once_with(
-        "https://mock-alation.com", 12345, "mock-token", None, None
+        "https://mock-alation.com", "refresh_token", (12345, "mock-token")
     )
     assert mcp_result is mock_mcp_instance
 

--- a/python/dist-mcp/tests/test_mcp_server.py
+++ b/python/dist-mcp/tests/test_mcp_server.py
@@ -2,6 +2,7 @@ import os
 import pytest
 from unittest.mock import patch, MagicMock
 from alation_ai_agent_mcp import server
+from alation_ai_agent_sdk import UserAccountAuthParams, ServiceAccountAuthParams
 
 
 @pytest.fixture(autouse=True)
@@ -16,7 +17,7 @@ def manage_environment_variables(monkeypatch):
         "ALATION_CLIENT_SECRET": os.environ.get("ALATION_CLIENT_SECRET"),
     }
     monkeypatch.setenv("ALATION_BASE_URL", "https://mock-alation.com")
-    monkeypatch.setenv("ALATION_AUTH_METHOD", "refresh_token")
+    monkeypatch.setenv("ALATION_AUTH_METHOD", "user_account")
     monkeypatch.setenv("ALATION_USER_ID", "12345")
     monkeypatch.setenv("ALATION_REFRESH_TOKEN", "mock-token")
     yield
@@ -93,7 +94,7 @@ def test_create_server_success(manage_environment_variables, mock_alation_sdk, m
 
     mock_mcp_class.assert_called_once_with(name="Alation MCP Server", version="0.1.0")
     mock_sdk_class.assert_called_once_with(
-        "https://mock-alation.com", "refresh_token", (12345, "mock-token")
+        "https://mock-alation.com", "user_account", UserAccountAuthParams(12345, "mock-token")
     )
     assert mcp_result is mock_mcp_instance
 
@@ -189,6 +190,6 @@ def test_create_server_service_account(manage_environment_variables, monkeypatch
 
     mock_mcp_class.assert_called_once_with(name="Alation MCP Server", version="0.1.0")
     mock_sdk_class.assert_called_once_with(
-        "https://mock-alation.com", "service_account", ("mock-client-id", "mock-client-secret")
+        "https://mock-alation.com", "service_account", ServiceAccountAuthParams("mock-client-id", "mock-client-secret")
     )
     assert mcp_result is mock_mcp_instance


### PR DESCRIPTION
## Summary
Introduce the ability to add credentials generated by `OAuth Client Applications` in the server. This is required as production Alation instances that use SAML as their Auth method do not support `user impersonation` and require the creation of a new user in their identity provider (like Okta) which could add friction for adoption

## TODO
- [ ] Update Examples
- [x] Update `help_links` 

## QA +1 instructions

1. Navigate to https://product-preview.mtse.alationcloud.com/admin/auth/
2. Create a new `OAuth Client Applications`
<img width="400" alt="create client" src="https://github.com/user-attachments/assets/48f4e8f5-f2e6-4862-865f-96e0cf7c5ab9" />

3. Copy the `client_id` and `client_secret` and save the values locally
4. Using either of the dists, try to init the server and ask a question
5. If using MCP inspector, use 
```zsh
npx @modelcontextprotocol/inspector@latest python path/to/alation-ai-agent-sdk/python/dist-mcp/alation_ai_agent_mcp/server.py -e ALATION_BASE_URL=https://product-preview.mtse.alationcloud.com LOG_LEVEL=DEBUG -e ALATION_CLIENT_SECRET=<paste-client-secret-here> -e ALATION_CLIENT_ID=<paste-client-id-here>
```

- Server should start without any error
- Questions should return data from the instance

check output logs to confirm as well

<img width="276" alt="Screenshot 2025-05-19 at 9 20 46 PM" src="https://github.com/user-attachments/assets/b31a222c-2945-43a3-b5d1-c2a3ed137235" />