### PR TITLE
AL-193494: update all examples and guides with new auth methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,4 +140,4 @@ logs/allie-sdk-*
 /tests/models/logs/
 /tests/logs/
 example.py
-
+customer_service.db

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The MCP integration provides an MCP-compatible server that exposes Alation's con
 
 - Python 3.10 or higher
 - Access to an Alation Data Catalog instance
-- A valid refresh token created from your user account in Alation ([instructions](https://developer.alation.com/dev/docs/authentication-into-alation-apis#create-a-refresh-token-via-the-ui))
+- A valid refresh token or client_id and secret. For more details, refer to the [Authentication Guide](https://github.com/Alation/alation-ai-agent-sdk/blob/main/guides/authentication.md).
 
 ### Installation
 

--- a/guides/README.md
+++ b/guides/README.md
@@ -4,6 +4,7 @@ Here are a handful of guides & examples to show you how to work with the Alation
 
 ## General
 
+- [Authentication](./authentication.md)
 - [Integration Planning](./planning.md)
 - [Using Signatures](./signature.md)
 - [Supported Object Types and Fields](./supported.md)

--- a/guides/authentication.md
+++ b/guides/authentication.md
@@ -25,7 +25,7 @@ This mode is designed for shared agents that are accessed by teams or organizati
 > **Note:** Only Server Admins can register OAuth client applications. If you require service account credentials, please contact your Alation administrator.
 
 ### Steps to Set Up:
-1. **Register an OAuth Client Application**: In your Alation instance, navigate to the Authentication settings page and register a new OAuth client application. Provide a unique name, set the access token duration, and assign a system user role. For detailed steps, refer to the [official documentation](https://docs.alation.com/en/latest/admins/AlationAPIs/AuthenticateAPICallsWithOAuth20.html).
+1. **Register an OAuth Client Application**: In your Alation instance, navigate to the Authentication settings page (`your-instance.alationcloud.com/admin/auth`) and register a new OAuth client application. Provide a unique name, set the access token duration, and assign a system user role. For detailed steps, refer to the [official documentation](https://docs.alation.com/en/latest/admins/AlationAPIs/AuthenticateAPICallsWithOAuth20.html).
 2. **Obtain Service Account Credentials**: After registering the application, securely store the client ID and client secret provided. Note that the client secret will not be shown again.
 3. **Set Environment Variables**:
    - `ALATION_BASE_URL`: The base URL of your Alation instance.

--- a/guides/authentication.md
+++ b/guides/authentication.md
@@ -1,0 +1,36 @@
+# Authentication Modes
+
+The Alation AI Agent SDK supports two distinct authentication modes, tailored to different use cases. This guide will help you understand when to use each mode and how to set them up.
+
+## User Account Authentication
+
+This mode is ideal for personal agents that are accessed and used by a single individual. It leverages the user's credentials to authenticate API requests. With this mode, the agent will only have access to the data and features that the user who created the token can see in the Alation UI.
+
+> **Note:** Any user can obtain a refresh token, provided that the admin has enabled this feature. If you do not see the option to generate a refresh token, please contact your Alation administrator.
+
+### Steps to Set Up:
+1. **Obtain a Refresh Token**: Generate a refresh token from the Alation UI on the User Account Settings > Authentication page. For detailed steps, refer to the [official documentation](https://developer.alation.com/dev/docs/authentication-into-alation-apis#create-a-refresh-token-via-the-ui).
+2. **Set Environment Variables**:
+   - `ALATION_BASE_URL`: The base URL of your Alation instance.
+   - `ALATION_AUTH_METHOD`: Set this to `user_account`.
+   - `ALATION_USER_ID`: Your unique user ID.
+   - `ALATION_REFRESH_TOKEN`: The refresh token you generated.
+3. **Initialize the SDK**:
+   Use the `UserAccountAuthParams` class to pass the required parameters when creating an instance of the SDK.
+
+## Service Account Authentication
+
+This mode is designed for shared agents that are accessed by teams or organizations. It uses service account credentials to authenticate API requests. With this mode, the agent will have access to the data and features allowed by the role assigned to the service account.
+
+> **Note:** Only Server Admins can register OAuth client applications. If you require service account credentials, please contact your Alation administrator.
+
+### Steps to Set Up:
+1. **Register an OAuth Client Application**: In your Alation instance, navigate to the Authentication settings page and register a new OAuth client application. Provide a unique name, set the access token duration, and assign a system user role. For detailed steps, refer to the [official documentation](https://docs.alation.com/en/latest/admins/AlationAPIs/AuthenticateAPICallsWithOAuth20.html).
+2. **Obtain Service Account Credentials**: After registering the application, securely store the client ID and client secret provided. Note that the client secret will not be shown again.
+3. **Set Environment Variables**:
+   - `ALATION_BASE_URL`: The base URL of your Alation instance.
+   - `ALATION_AUTH_METHOD`: Set this to `service_account`.
+   - `ALATION_CLIENT_ID`: The client ID provided during registration.
+   - `ALATION_CLIENT_SECRET`: The client secret provided during registration.
+4. **Initialize the SDK**:
+   Use the `ServiceAccountAuthParams` class to pass the required parameters when creating an instance of the SDK.

--- a/guides/mcp/claude_desktop.md
+++ b/guides/mcp/claude_desktop.md
@@ -7,8 +7,8 @@ This guide explains how to set up and use the Alation Model Context Protocol (MC
 - [Claude Desktop](https://claude.ai/download) application installed (macOS or Windows)
 - Python 3.10 or higher
 - Access to an Alation Data Catalog instance
-- A valid refresh token created from your user account in Alation ([instructions](https://developer.alation.com/dev/docs/authentication-into-alation-apis#create-a-refresh-token-via-the-ui))
-
+- A valid refresh token or client_id and secret. For more details, refer to the [Authentication Guide](https://github.com/Alation/alation-ai-agent-sdk/blob/main/guides/authentication.md).
+in calude
 ## Quick start
 
 ### Step 1: Configure Claude Desktop
@@ -23,7 +23,7 @@ This will create or open the configuration file at:
 - Windows: `%APPDATA%\Claude\claude_desktop_config.json`
 
 ### Method 1: Using `uvx`
-> This method requires minimal setup, uvx downloads and installs the package in a isolated environment; Ensure uvx is installed in your environment
+> This method requires minimal setup, uvx downloads and installs the package in an isolated environment; Ensure uvx is installed in your environment
 
 Add the following configuration to your `claude_desktop_config.json`. See [here](https://modelcontextprotocol.io/quickstart/user) for more details.
 
@@ -33,15 +33,22 @@ Add the following configuration to your `claude_desktop_config.json`. See [here]
     "alation": {
       "command": "uvx",
       "args": [
-        "--from", "alation-ai-agent-mcp","start-mcp-server"
+        "--from", "alation-ai-agent-mcp", "start-mcp-server"
       ],
       "env": {
-        "ALATION_BASE_URL": "https://company.alationcloud.com",
-        "ALATION_USER_ID": "123",
-        "ALATION_REFRESH_TOKEN":"<token>"
+        "ALATION_BASE_URL": "https://your-alation-instance.com",
+        "ALATION_AUTH_METHOD": "user_account", // or "service_account"
+
+        // For user account authentication
+        "ALATION_USER_ID": "your-user-id",
+        "ALATION_REFRESH_TOKEN": "your-refresh-token",
+
+        // For service account authentication
+        "ALATION_CLIENT_ID": "your-client-id",
+        "ALATION_CLIENT_SECRET": "your-client-secret"
       }
     }
-}
+  }
 }
 ```
 
@@ -60,14 +67,22 @@ where start-mcp-server  # On Windows
     "alation": {
       "command": "/full/path/to/start-mcp-server",
       "env": {
-        "ALATION_BASE_URL": "https://company.alationcloud.com",
-        "ALATION_USER_ID": "123",
-        "ALATION_REFRESH_TOKEN": "<token>"
+        "ALATION_BASE_URL": "https://your-alation-instance.com",
+        "ALATION_AUTH_METHOD": "user_account", // or "service_account"
+
+        // For user account authentication
+        "ALATION_USER_ID": "your-user-id",
+        "ALATION_REFRESH_TOKEN": "your-refresh-token",
+
+        // For service account authentication
+        "ALATION_CLIENT_ID": "your-client-id",
+        "ALATION_CLIENT_SECRET": "your-client-secret"
       }
     }
   }
 }
 ```
+
 ### Method 3: Using Docker
 > This assumes you've already locally built a docker image following the instructions from [this guide](https://github.com/Alation/alation-ai-agent-sdk/tree/main/python/dist-mcp/README.md#debugging-the-server)
 ```json
@@ -76,14 +91,21 @@ where start-mcp-server  # On Windows
     "alation-context-tool": {
       "command": "docker",
       "args": [
-        "run","-i","--rm",
-        "-e", "ALATION_BASE_URL=https://company.alationcloud.com",
-        "-e", "ALATION_USER_ID=123",
-        "-e", "ALATION_REFRESH_TOKEN=<token>",
+        "run", "-i", "--rm",
+        "-e", "ALATION_BASE_URL=https://your-alation-instance.com",
+        "-e", "ALATION_AUTH_METHOD=user_account", // or "service_account",
+
+        // For user account authentication
+        "-e", "ALATION_USER_ID=your-user-id",
+        "-e", "ALATION_REFRESH_TOKEN=your-refresh-token",
+
+        // For service account authentication
+        "-e", "ALATION_CLIENT_ID=your-client-id",
+        "-e", "ALATION_CLIENT_SECRET=your-client-secret",
         "alation-mcp-server:latest"
       ]
     }
-}
+  }
 }
 ```
 

--- a/guides/mcp/claude_desktop.md
+++ b/guides/mcp/claude_desktop.md
@@ -8,7 +8,7 @@ This guide explains how to set up and use the Alation Model Context Protocol (MC
 - Python 3.10 or higher
 - Access to an Alation Data Catalog instance
 - A valid refresh token or client_id and secret. For more details, refer to the [Authentication Guide](https://github.com/Alation/alation-ai-agent-sdk/blob/main/guides/authentication.md).
-in calude
+
 ## Quick start
 
 ### Step 1: Configure Claude Desktop

--- a/guides/mcp/librechat.md
+++ b/guides/mcp/librechat.md
@@ -1,4 +1,3 @@
-
 # Alation Context API Integration – LibreChat MCP Server
 
 This guide explains how to set up and use the **Alation Context API MCP server** with LibreChat. This enables LibreChat to retrieve Alation metadata (e.g., trusted tables, documentation, schema info) contextually during conversations with AI models.
@@ -10,7 +9,7 @@ This guide explains how to set up and use the **Alation Context API MCP server**
 - Installed and configured **LibreChat** client v0.7.8 or newer ([instructions](https://www.librechat.ai/docs/quick_start/local_setup))
 - Python 3.10 or higher
 - Access to an Alation Data Catalog instance
-- A valid refresh token created from your user account in Alation ([instructions](https://developer.alation.com/dev/docs/authentication-into-alation-apis#create-a-refresh-token-via-the-ui))
+- A valid refresh token or client_id and secret. For more details, refer to the [Authentication Guide](https://github.com/Alation/alation-ai-agent-sdk/blob/main/guides/authentication.md).
 
 ---
 
@@ -57,9 +56,16 @@ mcpServers:
       - "alation-ai-agent-mcp"
       - "start-mcp-server"
     env:
-      ALATION_REFRESH_TOKEN: "<your-refresh-token>"
-      ALATION_USER_ID: "<user-id>"
-      ALATION_BASE_URL: "https://company.mtse.alationcloud.com"
+      ALATION_BASE_URL: "https://your-alation-instance.com"
+      ALATION_AUTH_METHOD: "user_account"  # or "service_account"
+
+      # For user account authentication
+      ALATION_USER_ID: "your-user-id"
+      ALATION_REFRESH_TOKEN: "your-refresh-token"
+
+      # For service account authentication
+      ALATION_CLIENT_ID: "your-client-id"
+      ALATION_CLIENT_SECRET: "your-client-secret"
 ```
 This command automatically pulls the [alation-agent-mcp package](https://pypi.org/project/alation-ai-agent-mcp/) from Pypi and runs it when the LLM calls it.
 

--- a/guides/mcp/readme.md
+++ b/guides/mcp/readme.md
@@ -26,10 +26,21 @@ The Alation MCP Server exposes the following tools:
 ## Configuration
 
 The MCP server requires the following environment variables:
+
+### For User Account Authentication
+```bash
+export ALATION_BASE_URL="https://your-alation-instance.com"
+export ALATION_AUTH_METHOD="user_account"
+export ALATION_USER_ID="your-user-id"
+export ALATION_REFRESH_TOKEN="your-refresh-token"
 ```
-ALATION_BASE_URL - The URL of your Alation instance
-ALATION_USER_ID - Your numeric user ID in Alation
-ALATION_REFRESH_TOKEN - Your refresh token for Alation authentication
+
+### For Service Account Authentication
+```bash
+export ALATION_BASE_URL="https://your-alation-instance.com"
+export ALATION_AUTH_METHOD="service_account"
+export ALATION_CLIENT_ID="your-client-id"
+export ALATION_CLIENT_SECRET="your-client-secret"
 ```
 
 See the specific client guides for detailed configuration steps.

--- a/guides/mcp/testing_with_mcp_inspector.md
+++ b/guides/mcp/testing_with_mcp_inspector.md
@@ -6,7 +6,7 @@ This guide walks through the process of testing your Alation AI Agent SDK's Mode
 
 - Python 3.10 or higher
 - Access to an Alation Data Catalog instance
-- A valid refresh token created from your user account in Alation ([instructions](https://developer.alation.com/dev/docs/authentication-into-alation-apis#create-a-refresh-token-via-the-ui))
+- A valid refresh token or client_id and secret. For more details, refer to the [Authentication Guide](https://github.com/Alation/alation-ai-agent-sdk/blob/main/guides/authentication.md).
 - Node.js installed (for npx)
 
 ## Step 1: Set Required Environment Variables
@@ -16,16 +16,26 @@ The Alation MCP server requires three environment variables:
 ```bash
 # Set environment variables for your Alation instance
 export ALATION_BASE_URL="https://your-alation-instance.com"
+export ALATION_AUTH_METHOD="user_account"  # or "service_account"
+
+# For user account authentication
 export ALATION_USER_ID="123456"  # Your numeric user ID
 export ALATION_REFRESH_TOKEN="your-refresh-token"
+
+# For service account authentication
+export ALATION_CLIENT_ID="your-client-id"
+export ALATION_CLIENT_SECRET="your-client-secret"
 ```
 
 Verify the variables are properly set:
 
 ```bash
 echo $ALATION_BASE_URL
+echo $ALATION_AUTH_METHOD
 echo $ALATION_USER_ID
 echo $ALATION_REFRESH_TOKEN
+echo $ALATION_CLIENT_ID
+echo $ALATION_CLIENT_SECRET
 ```
 
 ## Step 2: Run the MCP Server with Inspector

--- a/guides/planning.md
+++ b/guides/planning.md
@@ -17,3 +17,11 @@ Field selection ensures your agent has the right context in order to achieve the
 We recommend starting the default fields then extending them as your use case(s) warrants. For more predicable results consider limiting any optional fields.
 
 See [Using Signatures](./signature.md) for how to put these integration ideas into practice.
+
+## Authentication
+
+The Alation AI Agent SDK supports two authentication methods:
+
+1. **User Account Authentication**: Ideal for personal agents. Requires a refresh token and user ID. Refer to the [Authentication Guide](./authentication.md) for setup instructions.
+
+2. **Service Account Authentication**: Designed for shared agents. Requires a client ID and client secret. Refer to the [Authentication Guide](./authentication.md) for setup instructions.

--- a/python/core-sdk/README.md
+++ b/python/core-sdk/README.md
@@ -22,7 +22,7 @@ To use the SDK, you'll need:
 
 - Python 3.10 or higher
 - Access to an Alation Data Catalog instance
-- A valid refresh token created from your user account in Alation ([instructions](https://developer.alation.com/dev/docs/authentication-into-alation-apis#create-a-refresh-token-via-the-ui))
+- A valid refresh token or client_id and secret. For more details, refer to the [Authentication Guide](https://github.com/Alation/alation-ai-agent-sdk/blob/main/guides/authentication.md).
 
 ## Quick Start
 

--- a/python/core-sdk/examples/basic_usage/README.md
+++ b/python/core-sdk/examples/basic_usage/README.md
@@ -14,7 +14,7 @@ The example illustrates:
 
 - Python 3.10 or higher
 - Access to an Alation Data Catalog instance
-- A valid refresh token created from your user account in Alation ([instructions](https://developer.alation.com/dev/docs/authentication-into-alation-apis#create-a-refresh-token-via-the-ui))
+- A valid refresh token or client_id and secret. For more details, refer to the [Authentication Guide](https://github.com/Alation/alation-ai-agent-sdk/blob/main/guides/authentication.md).
 
 ## Setup
 
@@ -28,8 +28,15 @@ pip install -r requirements.txt
 
 ```bash
 export ALATION_BASE_URL="https://your-alation-instance.com"
-export ALATION_USER_ID="your_alation_user_id"
-export ALATION_REFRESH_TOKEN="your_refresh_token"
+export ALATION_AUTH_METHOD="user_account"  # or "service_account"
+
+# For user account authentication
+export ALATION_USER_ID="your-user-id"
+export ALATION_REFRESH_TOKEN="your-refresh-token"
+
+# For service account authentication
+export ALATION_CLIENT_ID="your-client-id"
+export ALATION_CLIENT_SECRET="your-client-secret"
 ```
 
 ## Running the Example

--- a/python/core-sdk/examples/basic_usage/requirements.txt
+++ b/python/core-sdk/examples/basic_usage/requirements.txt
@@ -1,2 +1,2 @@
-alation-ai-agent-sdk>=0.2.0
+alation-ai-agent-sdk>=0.2.1
 requests~=2.32.0

--- a/python/core-sdk/examples/qa_chatbot/README.md
+++ b/python/core-sdk/examples/qa_chatbot/README.md
@@ -15,7 +15,7 @@ The example shows how to:
 
 - Python 3.10 or higher
 - Access to an Alation Data Catalog instance
-- A valid refresh token created from your user account in Alation ([instructions](https://developer.alation.com/dev/docs/authentication-into-alation-apis#create-a-refresh-token-via-the-ui))
+- A valid refresh token or client_id and secret. For more details, refer to the [Authentication Guide](https://github.com/Alation/alation-ai-agent-sdk/blob/main/guides/authentication.md).
 - OpenAI API key
 
 ## Setup
@@ -30,8 +30,16 @@ pip install -r requirements.txt
 
 ```bash
 export ALATION_BASE_URL="https://your-alation-instance.com"
-export ALATION_USER_ID="your_alation_user_id"
-export ALATION_REFRESH_TOKEN="your_refresh_token"
+export ALATION_AUTH_METHOD="user_account"  # or "service_account"
+
+# For user account authentication
+export ALATION_USER_ID="your-user-id"
+export ALATION_REFRESH_TOKEN="your-refresh-token"
+
+# For service account authentication
+export ALATION_CLIENT_ID="your-client-id"
+export ALATION_CLIENT_SECRET="your-client-secret"
+
 export OPENAI_API_KEY="your_openai_api_key"
 ```
 

--- a/python/core-sdk/examples/qa_chatbot/data_catalog_qa.py
+++ b/python/core-sdk/examples/qa_chatbot/data_catalog_qa.py
@@ -66,24 +66,20 @@ class DataCatalogQA:
         # Initialize OpenAI client
         self.client = openai.OpenAI(api_key=openai_api_key)
 
+        # Load auth method from env
+        auth_method = os.getenv("ALATION_AUTH_METHOD", "user_account")
+
         # Initialize Alation SDK
         self.sdk = AlationAIAgentSDK(
             base_url=self.base_url,
-            auth_method="user_account",  # or "service_account"
+            auth_method=auth_method,  # Use auth_method from env
             auth_params=UserAccountAuthParams(
                 user_id=self.user_id, refresh_token=self.refresh_token
-            ),
+            ) if auth_method == "user_account" else ServiceAccountAuthParams(
+                client_id=os.getenv("ALATION_CLIENT_ID"),
+                client_secret=os.getenv("ALATION_CLIENT_SECRET")
+            )
         )
-
-        # Uncomment the following block for service account authentication
-        # self.sdk = AlationAIAgentSDK(
-        #     base_url=self.base_url,
-        #     auth_method="service_account",
-        #     auth_params=ServiceAccountAuthParams(
-        #         client_id=os.getenv("ALATION_CLIENT_ID"),
-        #         client_secret=os.getenv("ALATION_CLIENT_SECRET")
-        #     )
-        # )
 
         # Initialize conversation history (including context)
         self.conversation_history = []

--- a/python/core-sdk/examples/qa_chatbot/requirements.txt
+++ b/python/core-sdk/examples/qa_chatbot/requirements.txt
@@ -1,4 +1,4 @@
-alation-ai-agent-sdk>=0.2.0
+alation-ai-agent-sdk>=0.2.1
 openai>=1.3.0
 requests~=2.32.0
 python-dotenv~=1.0.0

--- a/python/dist-langchain/README.md
+++ b/python/dist-langchain/README.md
@@ -14,7 +14,7 @@ The Langchain integration enables:
 
 - Python 3.10 or higher
 - Access to an Alation Data Catalog instance
-- A valid refresh token created from your user account in Alation ([instructions](https://developer.alation.com/dev/docs/authentication-into-alation-apis#create-a-refresh-token-via-the-ui))
+- A valid refresh token or client_id and secret. For more details, refer to the [Authentication Guide](https://github.com/Alation/alation-ai-agent-sdk/blob/main/guides/authentication.md).
 
 ## Installation
 

--- a/python/dist-langchain/alation_ai_agent_langchain/__init__.py
+++ b/python/dist-langchain/alation_ai_agent_langchain/__init__.py
@@ -2,4 +2,9 @@ from alation_ai_agent_sdk import AlationAIAgentSDK, UserAccountAuthParams, Servi
 
 from .toolkit import get_tools as get_langchain_tools
 
-__all__ = ["AlationAIAgentSDK", "get_langchain_tools"]
+__all__ = [
+    "AlationAIAgentSDK",
+    "get_langchain_tools",
+    "UserAccountAuthParams",
+    "ServiceAccountAuthParams",
+]

--- a/python/dist-langchain/alation_ai_agent_langchain/__init__.py
+++ b/python/dist-langchain/alation_ai_agent_langchain/__init__.py
@@ -1,4 +1,4 @@
-from alation_ai_agent_sdk import AlationAIAgentSDK
+from alation_ai_agent_sdk import AlationAIAgentSDK, UserAccountAuthParams, ServiceAccountAuthParams
 
 from .toolkit import get_tools as get_langchain_tools
 

--- a/python/dist-langchain/examples/basic_usage/README.md
+++ b/python/dist-langchain/examples/basic_usage/README.md
@@ -6,7 +6,7 @@ This example demonstrates how to create a basic LangChain agent that integrates 
 
 - Python 3.10 or higher
 - Access to an Alation Data Catalog instance
-- A valid refresh token created from your user account in Alation ([instructions](https://developer.alation.com/dev/docs/authentication-into-alation-apis#create-a-refresh-token-via-the-ui))
+- A valid refresh token or client_id and secret. For more details, refer to the [Authentication Guide](https://github.com/Alation/alation-ai-agent-sdk/blob/main/guides/authentication.md).
 - OpenAI API key
 
 Install all dependencies with:
@@ -21,8 +21,15 @@ pip install -r requirements.txt
 Before running the agent, set the following environment variables with your credentials:
 ```
 export ALATION_BASE_URL="https://your-alation-instance.com"
-export ALATION_USER_ID="your_alation_user_id"
-export ALATION_REFRESH_TOKEN="your_refresh_token"
+export ALATION_AUTH_METHOD="user_account"  # or "service_account"
+
+# For user account authentication
+export ALATION_USER_ID="your-user-id"
+export ALATION_REFRESH_TOKEN="your-refresh-token"
+
+# For service account authentication
+export ALATION_CLIENT_ID="your-client-id"
+export ALATION_CLIENT_SECRET="your-client-secret"
 export OPENAI_API_KEY="your_openai_api_key"
 ```
 

--- a/python/dist-langchain/examples/basic_usage/requirements.txt
+++ b/python/dist-langchain/examples/basic_usage/requirements.txt
@@ -1,4 +1,4 @@
-alation-ai-agent-langchain~=0.2.0
+alation-ai-agent-langchain~=0.2.1
 langchain-community==0.3.23
 langchain-openai==0.3.14
 openai==1.76.2

--- a/python/dist-langchain/examples/basic_usage/usage.py
+++ b/python/dist-langchain/examples/basic_usage/usage.py
@@ -19,34 +19,55 @@ base_url = os.getenv("ALATION_BASE_URL")
 user_id = os.getenv("ALATION_USER_ID")
 refresh_token = os.getenv("ALATION_REFRESH_TOKEN")
 openai_api_key = os.getenv("OPENAI_API_KEY")
+auth_method = os.getenv("ALATION_AUTH_METHOD", "user_account")
 
-if not all([base_url, user_id, refresh_token, openai_api_key]):
+if not all([base_url, user_id, refresh_token, openai_api_key, auth_method]):
     value_error_message = "Missing one or more required environment variables."
     raise ValueError(value_error_message)
 
-# Load auth method from env
-auth_method = os.getenv("ALATION_AUTH_METHOD", "user_account")
 
-# Init Alation SDK
-sdk = AlationAIAgentSDK(
-    base_url=base_url,
-    auth_method=auth_method,  # Use auth_method from env
-    auth_params=UserAccountAuthParams(user_id=int(user_id), refresh_token=refresh_token)
-    if auth_method == "user_account" else ServiceAccountAuthParams(
-        client_id=os.getenv("ALATION_CLIENT_ID"),
-        client_secret=os.getenv("ALATION_CLIENT_SECRET")
-    )
-)
+def initialize_sdk(base_url: str, auth_method: str) -> AlationAIAgentSDK:
+    """Initialize the Alation AI Agent SDK based on the authentication method."""
+    if auth_method == "user_account":
+        user_id_str = os.getenv("ALATION_USER_ID")
+        refresh_token = os.getenv("ALATION_REFRESH_TOKEN")
 
-# Uncomment the following block for service account authentication
-# sdk = AlationAIAgentSDK(
-#     base_url=base_url,
-#     auth_method="service_account",
-#     auth_params=ServiceAccountAuthParams(
-#         client_id=os.getenv("ALATION_CLIENT_ID"),
-#         client_secret=os.getenv("ALATION_CLIENT_SECRET")
-#     )
-# )
+        if not all([user_id_str, refresh_token]):
+            raise ValueError(
+                "Missing required environment variables for user account authentication. Please set ALATION_USER_ID and ALATION_REFRESH_TOKEN."
+            )
+
+        try:
+            user_id = int(user_id_str)
+        except ValueError:
+            raise ValueError(f"ALATION_USER_ID must be an integer, got: {user_id_str}")
+
+        return AlationAIAgentSDK(
+            base_url=base_url,
+            auth_method=auth_method,
+            auth_params=UserAccountAuthParams(user_id=user_id, refresh_token=refresh_token),
+        )
+
+    elif auth_method == "service_account":
+        client_id = os.getenv("ALATION_CLIENT_ID")
+        client_secret = os.getenv("ALATION_CLIENT_SECRET")
+
+        if not all([client_id, client_secret]):
+            raise ValueError(
+                "Missing required environment variables for service account authentication. Please set ALATION_CLIENT_ID and ALATION_CLIENT_SECRET."
+            )
+
+        return AlationAIAgentSDK(
+            base_url=base_url,
+            auth_method=auth_method,
+            auth_params=ServiceAccountAuthParams(client_id=client_id, client_secret=client_secret),
+        )
+
+    else:
+        raise ValueError(f"Unsupported ALATION_AUTH_METHOD: {auth_method}")
+
+
+sdk = initialize_sdk(base_url, auth_method)
 
 # LangChain tools
 tools = get_langchain_tools(sdk)

--- a/python/dist-langchain/examples/basic_usage/usage.py
+++ b/python/dist-langchain/examples/basic_usage/usage.py
@@ -4,7 +4,12 @@ from langchain.agents import AgentExecutor, create_openai_functions_agent
 from langchain.prompts import ChatPromptTemplate, MessagesPlaceholder
 from langchain_openai import ChatOpenAI
 
-from alation_ai_agent_langchain import AlationAIAgentSDK, get_langchain_tools
+from alation_ai_agent_langchain import (
+    AlationAIAgentSDK,
+    UserAccountAuthParams,
+    ServiceAccountAuthParams,
+    get_langchain_tools,
+)
 
 # Ignore warnings of print() usage
 # ruff: noqa: T201
@@ -20,7 +25,21 @@ if not all([base_url, user_id, refresh_token, openai_api_key]):
     raise ValueError(value_error_message)
 
 # Init Alation SDK
-sdk = AlationAIAgentSDK(base_url=base_url, user_id=int(user_id), refresh_token=refresh_token)
+sdk = AlationAIAgentSDK(
+    base_url=base_url,
+    auth_method="user_account",  # or "service_account"
+    auth_params=UserAccountAuthParams(user_id=int(user_id), refresh_token=refresh_token),
+)
+
+# Uncomment the following block for service account authentication
+# sdk = AlationAIAgentSDK(
+#     base_url=base_url,
+#     auth_method="service_account",
+#     auth_params=ServiceAccountAuthParams(
+#         client_id=os.getenv("ALATION_CLIENT_ID"),
+#         client_secret=os.getenv("ALATION_CLIENT_SECRET")
+#     )
+# )
 
 # LangChain tools
 tools = get_langchain_tools(sdk)

--- a/python/dist-langchain/examples/basic_usage/usage.py
+++ b/python/dist-langchain/examples/basic_usage/usage.py
@@ -24,11 +24,18 @@ if not all([base_url, user_id, refresh_token, openai_api_key]):
     value_error_message = "Missing one or more required environment variables."
     raise ValueError(value_error_message)
 
+# Load auth method from env
+auth_method = os.getenv("ALATION_AUTH_METHOD", "user_account")
+
 # Init Alation SDK
 sdk = AlationAIAgentSDK(
     base_url=base_url,
-    auth_method="user_account",  # or "service_account"
-    auth_params=UserAccountAuthParams(user_id=int(user_id), refresh_token=refresh_token),
+    auth_method=auth_method,  # Use auth_method from env
+    auth_params=UserAccountAuthParams(user_id=int(user_id), refresh_token=refresh_token)
+    if auth_method == "user_account" else ServiceAccountAuthParams(
+        client_id=os.getenv("ALATION_CLIENT_ID"),
+        client_secret=os.getenv("ALATION_CLIENT_SECRET")
+    )
 )
 
 # Uncomment the following block for service account authentication

--- a/python/dist-langchain/examples/multi_agent_return_eligibility/.env.example
+++ b/python/dist-langchain/examples/multi_agent_return_eligibility/.env.example
@@ -1,7 +1,14 @@
 # Alation configuration
 ALATION_BASE_URL=https://your-alation-instance.com
+ALATION_AUTH_METHOD=user_account  # or service_account
+
+# For user account authentication
 ALATION_USER_ID=12345
 ALATION_REFRESH_TOKEN=your-refresh-token
+
+# For service account authentication
+ALATION_CLIENT_ID=your-client-id
+ALATION_CLIENT_SECRET=your-client-secret
 
 # OpenAI configuration
 OPENAI_API_KEY=your-openai-api-key

--- a/python/dist-langchain/examples/multi_agent_return_eligibility/README.md
+++ b/python/dist-langchain/examples/multi_agent_return_eligibility/README.md
@@ -55,7 +55,7 @@ Each agent accesses specific information from the Alation catalog to make inform
 ### Prerequisites
 - Python 3.10 or higher
 - Access to an Alation Data Catalog instance
-- A valid refresh token created from your user account in Alation ([instructions](https://developer.alation.com/dev/docs/authentication-into-alation-apis#create-a-refresh-token-via-the-ui))
+- A valid refresh token or client_id and secret. For more details, refer to the [Authentication Guide](https://github.com/Alation/alation-ai-agent-sdk/blob/main/guides/authentication.md).
 - OpenAI API key
 
 ### Installation Steps
@@ -84,6 +84,19 @@ Each agent accesses specific information from the Alation catalog to make inform
 
 4. Configure environment variables:
    Duplicate `.env.example` file to `.env` in the root directory and update it.
+
+   ```bash
+   export ALATION_BASE_URL="https://your-alation-instance.com"
+   export ALATION_AUTH_METHOD="user_account"  # or "service_account"
+
+   # For user account authentication
+   export ALATION_USER_ID="your-user-id"
+   export ALATION_REFRESH_TOKEN="your-refresh-token"
+
+   # For service account authentication
+   export ALATION_CLIENT_ID="your-client-id"
+   export ALATION_CLIENT_SECRET="your-client-secret"
+   ```
 
 ## Running the Example
 

--- a/python/dist-langchain/examples/multi_agent_return_eligibility/config.py
+++ b/python/dist-langchain/examples/multi_agent_return_eligibility/config.py
@@ -10,8 +10,16 @@ load_dotenv()
 
 # Alation configuration
 ALATION_BASE_URL = os.getenv("ALATION_BASE_URL")
-ALATION_USER_ID = int(os.getenv("ALATION_USER_ID", "0"))
-ALATION_REFRESH_TOKEN = os.getenv("ALATION_REFRESH_TOKEN")
+ALATION_AUTH_METHOD = os.getenv("ALATION_AUTH_METHOD", "user_account")
+
+if ALATION_AUTH_METHOD == "user_account":
+    ALATION_USER_ID = int(os.getenv("ALATION_USER_ID", "0"))
+    ALATION_REFRESH_TOKEN = os.getenv("ALATION_REFRESH_TOKEN")
+elif ALATION_AUTH_METHOD == "service_account":
+    ALATION_CLIENT_ID = os.getenv("ALATION_CLIENT_ID")
+    ALATION_CLIENT_SECRET = os.getenv("ALATION_CLIENT_SECRET")
+else:
+    raise ValueError("Invalid ALATION_AUTH_METHOD. Must be 'user_account' or 'service_account'.")
 
 # LLM configuration
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")

--- a/python/dist-langchain/examples/multi_agent_return_eligibility/config.py
+++ b/python/dist-langchain/examples/multi_agent_return_eligibility/config.py
@@ -12,6 +12,12 @@ load_dotenv()
 ALATION_BASE_URL = os.getenv("ALATION_BASE_URL")
 ALATION_AUTH_METHOD = os.getenv("ALATION_AUTH_METHOD", "user_account")
 
+# Initialize all variables to avoid ImportError
+ALATION_USER_ID = None
+ALATION_REFRESH_TOKEN = None
+ALATION_CLIENT_ID = None
+ALATION_CLIENT_SECRET = None
+
 if ALATION_AUTH_METHOD == "user_account":
     ALATION_USER_ID = int(os.getenv("ALATION_USER_ID", "0"))
     ALATION_REFRESH_TOKEN = os.getenv("ALATION_REFRESH_TOKEN")

--- a/python/dist-langchain/examples/multi_agent_return_eligibility/requirements.txt
+++ b/python/dist-langchain/examples/multi_agent_return_eligibility/requirements.txt
@@ -1,5 +1,5 @@
-alation-ai-agent-sdk~=0.2
-alation-ai-agent-langchain~=0.2.0
+alation-ai-agent-sdk~=0.2.1
+alation-ai-agent-langchain~=0.2.1
 langchain>=0.1.0
 langchain-openai>=0.0.2
 langgraph>=0.0.20

--- a/python/dist-mcp/README.md
+++ b/python/dist-mcp/README.md
@@ -15,7 +15,7 @@ The MCP integration enables:
 
 - Python 3.10 or higher
 - Access to an Alation Data Catalog instance
-- A valid refresh token created from your user account in Alation ([instructions](https://developer.alation.com/dev/docs/authentication-into-alation-apis#create-a-refresh-token-via-the-ui))
+- A valid refresh token or client_id and secret. For more details, refer to the [Authentication Guide](https://github.com/Alation/alation-ai-agent-sdk/blob/main/guides/authentication.md).
 
 ## Setup
 


### PR DESCRIPTION
Updated all docs, examples and guides with the new auth_methods and required env vars.

To Test:
- [x] mcp inspector
- [x] claude desktop
- [x] librechat
- [x] core-sdk/examples/basic_usage
- [x] core-sdk/examples/qa_chatbot
- [x] dist-langchain/examples/basic_usage
- [x] dist-langchain/examples/multi_agent_return_eligibility