### PR TITLE
feat: AL-198244: add bulk lineage tool

### DIFF
--- a/guides/mcp/claude_desktop.md
+++ b/guides/mcp/claude_desktop.md
@@ -33,7 +33,7 @@ Add the following configuration to your `claude_desktop_config.json`. See [here]
     "alation": {
       "command": "uvx",
       "args": [
-        "--from", "alation-ai-agent-mcp", "start-mcp-server"
+        "--from", "alation-ai-agent-mcp", "start-alation-mcp-server"
       ],
       "env": {
         "ALATION_BASE_URL": "https://your-alation-instance.com",
@@ -55,17 +55,17 @@ Add the following configuration to your `claude_desktop_config.json`. See [here]
 ### Method 2: Using `pip`
 1. Install the package: ```pip install alation-ai-agent-mcp``
 
-2. After installation, you can use the start-mcp-server command. Find the installation paths.
+2. After installation, you can use the start-alation-mcp-server command. Find the installation paths.
 ```
-which start-mcp-server  # On macOS/Linux
-where start-mcp-server  # On Windows
+which start-alation-mcp-server  # On macOS/Linux
+where start-alation-mcp-server  # On Windows
 ```
 3. Add the following configuration to your `claude_desktop_config.json`.
 ```json
 {
   "mcpServers": {
     "alation": {
-      "command": "/full/path/to/start-mcp-server",
+      "command": "/full/path/to/start-alation-mcp-server",
       "env": {
         "ALATION_BASE_URL": "https://your-alation-instance.com",
         "ALATION_AUTH_METHOD": "user_account", // or "service_account"

--- a/guides/mcp/code_editors.md
+++ b/guides/mcp/code_editors.md
@@ -20,7 +20,7 @@ Ensure you are using a recent version of your code editor. For VS Code, use **Ap
             "alation-mcp-server": {
                 "command": "uvx",
                 "args": [
-                    "--from", "alation-ai-agent-mcp", "start-mcp-server"
+                    "--from", "alation-ai-agent-mcp", "start-alation-mcp-server"
                 ],
                 "env": {
                     "ALATION_BASE_URL": "https://company.alationcloud.com",
@@ -92,7 +92,7 @@ The configuration format is the same as described above. Be sure to fill out the
     "alation-mcp-server": {
       "command": "uvx",
       "args": [
-        "--from", "alation-ai-agent-mcp", "start-mcp-server"
+        "--from", "alation-ai-agent-mcp", "start-alation-mcp-server"
       ],
       "env": {
           "ALATION_BASE_URL": "https://company.alationcloud.com",

--- a/guides/mcp/librechat.md
+++ b/guides/mcp/librechat.md
@@ -54,7 +54,7 @@ mcpServers:
     args:
       - "--from"
       - "alation-ai-agent-mcp"
-      - "start-mcp-server"
+      - "start-alation-mcp-server"
     env:
       ALATION_BASE_URL: "https://your-alation-instance.com"
       ALATION_AUTH_METHOD: "user_account"  # or "service_account"

--- a/guides/mcp/testing_with_mcp_inspector.md
+++ b/guides/mcp/testing_with_mcp_inspector.md
@@ -44,9 +44,9 @@ You have several options to run your server with the MCP Inspector:
 
 ### Option 1: Using uvx
 ```bash
-uvx --from alation-ai-agent-mcp start-mcp-server
+uvx --from alation-ai-agent-mcp start-alation-mcp-server
 # Then run the MCP Inspector:
-npx @modelcontextprotocol/inspector uvx --from alation-ai-agent-mcp start-mcp-server
+npx @modelcontextprotocol/inspector uvx --from alation-ai-agent-mcp start-alation-mcp-server
 ```
 
 ### Option 2: Using pip with Inspector
@@ -54,7 +54,7 @@ npx @modelcontextprotocol/inspector uvx --from alation-ai-agent-mcp start-mcp-se
 # Install the package via pip
 pip install alation-ai-agent-mcp
 # Then run:
-npx @modelcontextprotocol/inspector start-mcp-server
+npx @modelcontextprotocol/inspector start-alation-mcp-server
 ```
 
 ### Option 3: Direct python execution

--- a/python/core-sdk/alation_ai_agent_sdk/__init__.py
+++ b/python/core-sdk/alation_ai_agent_sdk/__init__.py
@@ -8,7 +8,7 @@ from .sdk import (
     AlationAIAgentSDK,
     AlationTools,
 )
-from .tools import env_to_tool_list
+from .tools import csv_str_to_tool_list
 
 __all__ = [
     "AlationAIAgentSDK",
@@ -17,5 +17,5 @@ __all__ = [
     "AlationAPIError",
     "UserAccountAuthParams",
     "ServiceAccountAuthParams",
-    "env_to_tool_list",
+    "csv_str_to_tool_list",
 ]

--- a/python/core-sdk/alation_ai_agent_sdk/__init__.py
+++ b/python/core-sdk/alation_ai_agent_sdk/__init__.py
@@ -1,10 +1,21 @@
-from .sdk import AlationAIAgentSDK
-from .api import AlationAPI, AlationAPIError, UserAccountAuthParams, ServiceAccountAuthParams
+from .api import (
+    AlationAPI,
+    AlationAPIError,
+    UserAccountAuthParams,
+    ServiceAccountAuthParams,
+)
+from .sdk import (
+    AlationAIAgentSDK,
+    AlationTools,
+)
+from .tools import env_to_tool_list
 
 __all__ = [
     "AlationAIAgentSDK",
+    "AlationTools",
     "AlationAPI",
     "AlationAPIError",
     "UserAccountAuthParams",
-    "ServiceAccountAuthParams"
+    "ServiceAccountAuthParams",
+    "env_to_tool_list",
 ]

--- a/python/core-sdk/alation_ai_agent_sdk/api.py
+++ b/python/core-sdk/alation_ai_agent_sdk/api.py
@@ -624,7 +624,7 @@ class AlationAPI:
         Fetch lineage information from Alation's catalog for a given object / root node.
 
         Args:
-            root_node (LineageRootNode): The root node to start lineage from.
+            root_nodes (List[LineageRootNode]): The root nodes to start lineage from.
             direction (LineageDirectionType): The direction of lineage to fetch, either "upstream" or "downstream".
             limit (int, optional): The maximum number of nodes to return. Defaults to the maximum 1,000.
             batch_size (int, optional): The size of each batch for chunked processing. Defaults to 1,000.
@@ -637,7 +637,7 @@ class AlationAPI:
             allowed_otypes (LineageOTypeFilterType, optional): A list of allowed object types to filter lineage nodes. Defaults to None.
             time_from (LineageTimestampType, optional): The start time for temporal lineage filtering. Defaults to None.
             time_to (LineageTimestampType, optional): The end time for temporal lineage filtering. Defaults to None.
-        
+
         Returns:
             Dict[str, Dict[str, any]]]: A dictionary containing the lineage `graph` and `pagination` information.
 

--- a/python/core-sdk/alation_ai_agent_sdk/api.py
+++ b/python/core-sdk/alation_ai_agent_sdk/api.py
@@ -18,7 +18,7 @@ from alation_ai_agent_sdk.lineage import (
     LineageOTypeFilterType,
     LineagePagination,
     LineageRootNode,
-    LineageAllowedSchemaIdsType,
+    LineageExcludedSchemaIdsType,
     LineageTimestampType,
     LineageDirectionType,
 )
@@ -701,7 +701,7 @@ class AlationAPI:
         show_temporal_objects: bool,
         design_time: LineageDesignTimeType,
         max_depth: int,
-        allowed_schema_ids: LineageAllowedSchemaIdsType,
+        excluded_schema_ids: LineageExcludedSchemaIdsType,
         allowed_otypes: LineageOTypeFilterType,
         time_from: LineageTimestampType,
         time_to: LineageTimestampType,
@@ -721,7 +721,7 @@ class AlationAPI:
             show_temporal_objects (bool, optional): Whether to include temporary objects in the lineage. Defaults to False.
             design_time (LineageDesignTimeType, optional): The design time option to filter lineage. Defaults to LineageDesignTimeOptions.EITHER_DESIGN_OR_RUN_TIME.
             max_depth (int, optional): The maximum depth to traverse in the lineage graph. Defaults to 10.
-            allowed_schema_ids (LineageAllowedSchemaIdsType, optional): A list of allowed schema IDs to filter lineage nodes. Defaults to None.
+            excluded_schema_ids (LineageExcludedSchemaIdsType, optional): A list of excluded schema IDs to filter lineage nodes. Defaults to None.
             allowed_otypes (LineageOTypeFilterType, optional): A list of allowed object types to filter lineage nodes. Defaults to None.
             time_from (LineageTimestampType, optional): The start time for temporal lineage filtering. Defaults to None.
             time_to (LineageTimestampType, optional): The end time for temporal lineage filtering. Defaults to None.
@@ -764,11 +764,7 @@ class AlationAPI:
                     "from": time_from,
                     "to": time_to,
                 },
-                # WARNING: There is a discrepancy between the schema_filter parameter description vs its behavior in the MT service.
-                # In the service it appears to exclude objects that are part of the schema filter rather than restricting objects to only
-                # those schema ids.
-                # TODO: consider removing the option and parameter temporarily.
-                "schema_filter": allowed_schema_ids,
+                "schema_filter": excluded_schema_ids,
                 "temp_filter": show_temporal_objects,
                 "design_time": design_time,
             },

--- a/python/core-sdk/alation_ai_agent_sdk/api.py
+++ b/python/core-sdk/alation_ai_agent_sdk/api.py
@@ -4,7 +4,6 @@ import json
 from typing import Any, Dict, List, NamedTuple, Optional, Union
 from http import HTTPStatus
 from alation_ai_agent_sdk.lineage_filtering import filter_graph
-from alation_ai_agent_sdk.lineage_filtering import filter_graph
 import requests
 import requests.exceptions
 from typing_extensions import TypedDict

--- a/python/core-sdk/alation_ai_agent_sdk/api.py
+++ b/python/core-sdk/alation_ai_agent_sdk/api.py
@@ -99,6 +99,7 @@ class AlationAPI:
         auth_method: str,
         auth_params: AuthParams,
         dist_version: Optional[str] = None,
+        skip_instance_info: Optional[bool] = False,
     ):
         self.base_url = base_url.rstrip("/")
         self.access_token: Optional[str] = None
@@ -128,7 +129,8 @@ class AlationAPI:
 
         logger.debug(f"AlationAPI initialized with auth method: {self.auth_method}")
 
-        self._fetch_and_cache_instance_info()
+        if not skip_instance_info:
+            self._fetch_and_cache_instance_info()
 
     def _fetch_and_cache_instance_info(self):
         """

--- a/python/core-sdk/alation_ai_agent_sdk/api.py
+++ b/python/core-sdk/alation_ai_agent_sdk/api.py
@@ -715,7 +715,11 @@ class AlationAPI:
                     "from": time_from,
                     "to": time_to,
                 },
-                "schema_filter": allowed_schema_ids, # TODO: double check these are allowed vs disallowed
+                # WARNING: There is a discrepancy between the schema_filter parameter description vs its behavior in the MT service.
+                # In the service it appears to exclude objects that are part of the schema filter rather than restricting objects to only
+                # those schema ids.
+                # TODO: consider removing the option and parameter temporarily.
+                "schema_filter": allowed_schema_ids,
                 "temp_filter": show_temporal_objects,
                 "design_time": design_time,
             },

--- a/python/core-sdk/alation_ai_agent_sdk/api.py
+++ b/python/core-sdk/alation_ai_agent_sdk/api.py
@@ -1,11 +1,12 @@
 import logging
 import urllib.parse
 import json
-from typing import Any, Dict, List, Optional
-from http import HTTPStatus
-from alation_ai_agent_sdk.lineage_filtering import filter_graph
 import requests
 import requests.exceptions
+from typing import Any, Dict, List, Optional
+from http import HTTPStatus
+from uuid import uuid4
+from alation_ai_agent_sdk.lineage_filtering import filter_graph
 from .types import (
     UserAccountAuthParams,
     ServiceAccountAuthParams,
@@ -679,13 +680,14 @@ class AlationAPI:
                     "to": time_to,
                 },
                 "schema_filter": excluded_schema_ids,
-                "temp_filter": show_temporal_objects,
                 "design_time": design_time,
             },
-            "request_id": pagination.get("request_id", "") if pagination else "",
+            "request_id": pagination.get("request_id") if pagination else uuid4().hex,
             "cursor": pagination.get("cursor", 0) if pagination else 0,
             "batch_size": limit if processing_mode == LineageGraphProcessingOptions.COMPLETE else pagination.get("batch_size", limit) if pagination else batch_size,
         }
+        if show_temporal_objects:
+            lineage_request_dict["filters"]["temp_filter"] = show_temporal_objects
         url = f"{self.base_url}/integration/v2/bulk_lineage/"
         try:
             response = requests.post(

--- a/python/core-sdk/alation_ai_agent_sdk/api.py
+++ b/python/core-sdk/alation_ai_agent_sdk/api.py
@@ -1,10 +1,27 @@
 import logging
 import urllib.parse
 import json
-from typing import Dict, Any, Optional, Union, NamedTuple
+from typing import Any, Dict, List, Optional, Union
 from http import HTTPStatus
+from alation_ai_agent_sdk.lineage_filtering import filter_graph
+from alation_ai_agent_sdk.lineage_filtering import filter_graph
 import requests
 import requests.exceptions
+
+from alation_ai_agent_sdk.lineage import (
+    LineageBatchSizeType,
+    LineageDesignTimeType,
+    LineageGraphProcessingOptions,
+    LineageGraphProcessingType,
+    LineageKeyTypeType,
+    LineageOTypeFilterType,
+    LineagePagination,
+    LineageRootNode,
+    LineageAllowedSchemaIdsType,
+    LineageTimestampType,
+    LineageDirectionType,
+)
+
 
 AUTH_METHOD_USER_ACCOUNT = "user_account"
 AUTH_METHOD_SERVICE_ACCOUNT = "service_account"
@@ -144,6 +161,8 @@ class ServiceAccountAuthParams(NamedTuple):
 
 
 AuthParams = Union[UserAccountAuthParams, ServiceAccountAuthParams]
+
+
 
 
 class AlationAPI:
@@ -622,3 +641,110 @@ class AlationAPI:
             raise ValueError(
                 "You must provide either a product_id or a query to search for data products."
             )
+
+    def get_bulk_lineage(
+        self,
+        root_nodes: List[LineageRootNode],
+        direction: LineageDirectionType,
+        limit: int,
+        batch_size: LineageBatchSizeType,
+        processing_mode: LineageGraphProcessingType,
+        show_temporal_objects: bool,
+        design_time: LineageDesignTimeType,
+        max_depth: int,
+        allowed_schema_ids: LineageAllowedSchemaIdsType,
+        allowed_otypes: LineageOTypeFilterType,
+        time_from: LineageTimestampType,
+        time_to: LineageTimestampType,
+        key_type: LineageKeyTypeType,
+        pagination: Optional[LineagePagination] = None,
+    ) -> dict:
+        """
+        Fetch lineage information from Alation's catalog for a given object / root node.
+
+        Args:
+            root_node (LineageRootNode): The root node to start lineage from.
+            direction (LineageDirectionType): The direction of lineage to fetch, either "upstream" or "downstream".
+            limit (int, optional): The maximum number of nodes to return. Defaults to 1000.
+            batch_size (int, optional): The size of each batch for chunked processing. Defaults to 1000.
+            pagination (LineagePagination, optional): Pagination parameters only used with chunked processing.
+            processing_mode (LineageGraphProcessingType, optional): The processing mode for lineage graph. Strongly recommended to use 'complete' for full lineage graphs.
+            show_temporal_objects (bool, optional): Whether to include temporary objects in the lineage. Defaults to False.
+            design_time (LineageDesignTimeType, optional): The design time option to filter lineage. Defaults to LineageDesignTimeOptions.EITHER_DESIGN_OR_RUN_TIME.
+            max_depth (int, optional): The maximum depth to traverse in the lineage graph. Defaults to 10.
+            allowed_schema_ids (LineageAllowedSchemaIdsType, optional): A list of allowed schema IDs to filter lineage nodes. Defaults to None.
+            allowed_otypes (LineageOTypeFilterType, optional): A list of allowed object types to filter lineage nodes. Defaults to None.
+            time_from (LineageTimestampType, optional): The start time for temporal lineage filtering. Defaults to None.
+            time_to (LineageTimestampType, optional): The end time for temporal lineage filtering. Defaults to None.
+        
+        Returns:
+            Dict[str, Dict[str, any]]]: A dictionary containing the lineage `graph` and `pagination` information.
+
+        Raises:
+            ValueError: When argument combinations are invalid, such as:
+                pagination in complete processing mode,
+                allowed_otypes in chunked processing mode
+            AlationAPIError: On network, API, or response errors.
+        """
+        self._with_valid_token()
+
+        headers = {
+            "Token": self.access_token,
+            "Accept": "application/json",
+        }
+
+        # Filter out any incompatible options
+        if allowed_otypes is not None and processing_mode != LineageGraphProcessingOptions.COMPLETE:
+            raise ValueError("allowed_otypes is only supported in 'complete' processing mode.")
+        if pagination is not None and processing_mode == LineageGraphProcessingOptions.COMPLETE:
+            raise ValueError("Pagination is only supported in 'chunked' processing mode.")
+
+        lineage_request_dict = {
+            "key_type": key_type,
+            "root_nodes": root_nodes,
+            "direction": direction,
+            "limit": limit,
+            "filters": {
+                "depth": max_depth,
+                "time_filter": {
+                    "from": time_from,
+                    "to": time_to,
+                },
+                "schema_filter": allowed_schema_ids, # TODO: double check these are allowed vs disallowed
+                "temp_filter": show_temporal_objects,
+                "design_time": design_time,
+            },
+            "request_id": pagination.get("request_id", "") if pagination else "",
+            "cursor": pagination.get("cursor", 0) if pagination else 0,
+            "batch_size": limit if processing_mode == LineageGraphProcessingOptions.COMPLETE else pagination.get("batch_size", limit) if pagination else batch_size,
+        }
+        url = f"{self.base_url}/integration/v2/bulk_lineage/"
+        try:
+            response = requests.post(
+                url, headers=headers, json=lineage_request_dict, timeout=60
+            )
+            response.raise_for_status()
+            response_data = response.json()
+            if "graph" in response_data and processing_mode == LineageGraphProcessingOptions.COMPLETE:
+                if allowed_otypes is not None:
+                    allowed_otypes_set = set(allowed_otypes)
+                    response_data["graph"] = filter_graph(
+                        response_data["graph"], allowed_otypes_set
+                    )
+            request_id = response_data.get("request_id", "")
+            # Deliberately Pascal cased to match implementation. We'll change it to be consistent for anything
+            # invoking the tool.
+            pagination = response_data.get("Pagination", None)
+            if pagination is not None:
+                new_pagination = {
+                    "request_id": request_id,
+                    "cursor": pagination.get("cursor", 0),
+                    "batch_size": pagination.get("batch_size", batch_size),
+                    "has_more": pagination.get("has_more", False),
+                }
+                response_data["pagination"] = new_pagination
+                del response_data["request_id"]
+            response_data["direction"] = direction
+            return response_data
+        except requests.RequestException as e:
+            self._handle_request_error(e, f"getting lineage for: {json.dumps(lineage_request_dict)}")

--- a/python/core-sdk/alation_ai_agent_sdk/lineage.py
+++ b/python/core-sdk/alation_ai_agent_sdk/lineage.py
@@ -101,9 +101,6 @@ def make_lineage_kwargs(
     if excluded_schema_ids is None:
         excluded_schema_ids = []
 
-    if allowed_otypes is None:
-        allowed_otypes = []
-
     if time_from is None:
         time_from = ""
 

--- a/python/core-sdk/alation_ai_agent_sdk/lineage.py
+++ b/python/core-sdk/alation_ai_agent_sdk/lineage.py
@@ -1,4 +1,5 @@
-from typing import List, Literal, Optional, TypedDict, Union
+from typing import List, Literal, Optional, Union
+from typing_extensions import TypedDict
 
 class LineageDesignTimeOptions:
     ONLY_DESIGN_TIME = 1

--- a/python/core-sdk/alation_ai_agent_sdk/lineage.py
+++ b/python/core-sdk/alation_ai_agent_sdk/lineage.py
@@ -79,7 +79,7 @@ def make_lineage_kwargs(
         show_temporal_objects (Optional[bool]): Whether to show temporal objects.
         design_time (Optional[LineageDesignTimeType]): The design time option.
         max_depth (Optional[int]): The maximum depth for the query.
-        excluded_schema_ids (Optional[LineageExcludedSchemaIdsType]): The allowed schema IDs.
+        excluded_schema_ids (Optional[LineageExcludedSchemaIdsType]): The excluded schema IDs.
         allowed_otypes (Optional[LineageOTypeFilterType]): The allowed object types.
         time_from (Optional[LineageTimestampType]): The start time for the query.
         time_to (Optional[LineageTimestampType]): The end time for the query.

--- a/python/core-sdk/alation_ai_agent_sdk/lineage.py
+++ b/python/core-sdk/alation_ai_agent_sdk/lineage.py
@@ -24,7 +24,7 @@ class LineagePagination(TypedDict):
     request_id: str
 
 type LineageDirectionType = Literal["upstream", "downstream"]
-type LineageAllowedSchemaIdsType = List[int]
+type LineageExcludedSchemaIdsType = List[int]
 type LineageTimestampType = str
 type LineageKeyTypeType = Literal["id", "fully_qualified_name"]
 type LineageDesignTimeType = Literal[1, 2, 3]
@@ -63,7 +63,7 @@ def make_lineage_kwargs(
     show_temporal_objects: Optional[bool] = False,
     design_time: Optional[LineageDesignTimeType] = None,
     max_depth: Optional[int] = 10,
-    allowed_schema_ids: Optional[LineageAllowedSchemaIdsType] = None,
+    excluded_schema_ids: Optional[LineageExcludedSchemaIdsType] = None,
     allowed_otypes: Optional[LineageOTypeFilterType] = None,
     time_from: Optional[LineageTimestampType] = None,
     time_to: Optional[LineageTimestampType] = None,
@@ -77,7 +77,7 @@ def make_lineage_kwargs(
         show_temporal_objects (Optional[bool]): Whether to show temporal objects.
         design_time (Optional[LineageDesignTimeType]): The design time option.
         max_depth (Optional[int]): The maximum depth for the query.
-        allowed_schema_ids (Optional[LineageAllowedSchemaIdsType]): The allowed schema IDs.
+        excluded_schema_ids (Optional[LineageExcludedSchemaIdsType]): The allowed schema IDs.
         allowed_otypes (Optional[LineageOTypeFilterType]): The allowed object types.
         time_from (Optional[LineageTimestampType]): The start time for the query.
         time_to (Optional[LineageTimestampType]): The end time for the query.
@@ -96,8 +96,8 @@ def make_lineage_kwargs(
     if design_time is None:
         design_time = LineageDesignTimeOptions.EITHER_DESIGN_OR_RUN_TIME
 
-    if allowed_schema_ids is None:
-        allowed_schema_ids = []
+    if excluded_schema_ids is None:
+        excluded_schema_ids = []
 
     if allowed_otypes is None:
         allowed_otypes = []
@@ -114,7 +114,7 @@ def make_lineage_kwargs(
         "show_temporal_objects": show_temporal_objects,
         "design_time": design_time,
         "max_depth": max_depth,
-        "allowed_schema_ids": allowed_schema_ids,
+        "excluded_schema_ids": excluded_schema_ids,
         "allowed_otypes": allowed_otypes,
         "time_from": time_from,
         "time_to": time_to,

--- a/python/core-sdk/alation_ai_agent_sdk/lineage.py
+++ b/python/core-sdk/alation_ai_agent_sdk/lineage.py
@@ -23,16 +23,17 @@ class LineagePagination(TypedDict):
     has_more: bool
     request_id: str
 
-type LineageDirectionType = Literal["upstream", "downstream"]
-type LineageExcludedSchemaIdsType = List[int]
-type LineageTimestampType = str
-type LineageKeyTypeType = Literal["id", "fully_qualified_name"]
-type LineageDesignTimeType = Literal[1, 2, 3]
-type LineageOTypeFilterType = Optional[List[str]]
-type LineageGraphProcessingType = Literal['chunked', 'complete']
-type LineageBatchSizeType = int
 
-type LineageResponseRequestIdType = str
+LineageDirectionType = Literal["upstream", "downstream"]
+LineageExcludedSchemaIdsType = List[int]
+LineageTimestampType = str
+LineageKeyTypeType = Literal["id", "fully_qualified_name"]
+LineageDesignTimeType = Literal[1, 2, 3]
+LineageOTypeFilterType = Optional[List[str]]
+LineageGraphProcessingType = Literal['chunked', 'complete']
+LineageBatchSizeType = int
+
+LineageResponseRequestIdType = str
 
 class LineageResponseGraphNeighborNode(TypedDict):
     id: Union[str, int]

--- a/python/core-sdk/alation_ai_agent_sdk/lineage.py
+++ b/python/core-sdk/alation_ai_agent_sdk/lineage.py
@@ -1,0 +1,122 @@
+from typing import List, Literal, Optional, TypedDict, Union
+
+class LineageDesignTimeOptions:
+    ONLY_DESIGN_TIME = 1
+    ONLY_RUN_TIME = 2
+    EITHER_DESIGN_OR_RUN_TIME = 3
+
+class LineageDirectionOptions:
+    UPSTREAM = 'upstream'
+    DOWNSTREAM = 'downstream'
+
+class LineageGraphProcessingOptions:
+    CHUNKED = 'chunked'
+    COMPLETE = 'complete'
+
+class LineageRootNode(TypedDict):
+    id: Union[str, int]
+    otype: str
+
+class LineagePagination(TypedDict):
+    cursor: int
+    batch_size: int
+    has_more: bool
+    request_id: str
+
+type LineageDirectionType = Literal["upstream", "downstream"]
+type LineageAllowedSchemaIdsType = List[int]
+type LineageTimestampType = str
+type LineageKeyTypeType = Literal["id", "fully_qualified_name"]
+type LineageDesignTimeType = Literal[1, 2, 3]
+type LineageOTypeFilterType = Optional[List[str]]
+type LineageGraphProcessingType = Literal['chunked', 'complete']
+type LineageBatchSizeType = int
+
+type LineageResponseRequestIdType = str
+
+class LineageResponseGraphNeighborNode(TypedDict):
+    id: Union[str, int]
+    otype: str
+    # These keys may not be present in all nodes. Please use obj.get() to access them safely.
+    fully_qualified_name: str
+    is_external: bool
+    is_temp: bool
+
+class LineageResponseGraphNode(TypedDict):
+    id: Union[str, int]
+    otype: str
+    # These keys may not be present in all nodes. Please use obj.get() to access them safely.
+    fully_qualified_name: str
+    is_external: bool
+    is_temp: bool
+    neighbors: List[LineageResponseGraphNeighborNode]
+
+class LineageToolResponse(TypedDict):
+    graph: List[LineageResponseGraphNode]
+    direction: LineageDirectionType
+    pagination: Optional[LineagePagination]
+
+
+def make_lineage_kwargs(
+    root_node: LineageRootNode,
+    processing_mode: Optional[LineageGraphProcessingType] = None,
+    show_temporal_objects: Optional[bool] = False,
+    design_time: Optional[LineageDesignTimeType] = None,
+    max_depth: Optional[int] = 10,
+    allowed_schema_ids: Optional[LineageAllowedSchemaIdsType] = None,
+    allowed_otypes: Optional[LineageOTypeFilterType] = None,
+    time_from: Optional[LineageTimestampType] = None,
+    time_to: Optional[LineageTimestampType] = None,
+):
+    """
+    Prepare the keyword arguments for the lineage API call.
+
+    Args:
+        root_node (LineageRootNode): The root node for the lineage query.
+        processing_mode (Optional[LineageGraphProcessingType]): The processing mode for the query.
+        show_temporal_objects (Optional[bool]): Whether to show temporal objects.
+        design_time (Optional[LineageDesignTimeType]): The design time option.
+        max_depth (Optional[int]): The maximum depth for the query.
+        allowed_schema_ids (Optional[LineageAllowedSchemaIdsType]): The allowed schema IDs.
+        allowed_otypes (Optional[LineageOTypeFilterType]): The allowed object types.
+        time_from (Optional[LineageTimestampType]): The start time for the query.
+        time_to (Optional[LineageTimestampType]): The end time for the query.
+
+    Returns:
+        dict: The keyword arguments for the lineage API call.
+    """
+
+    if processing_mode is None:
+        # This is much simpler for the LLM to understand
+        processing_mode = LineageGraphProcessingOptions.COMPLETE
+
+    if show_temporal_objects is None:
+        show_temporal_objects = False
+
+    if design_time is None:
+        design_time = LineageDesignTimeOptions.EITHER_DESIGN_OR_RUN_TIME
+
+    if allowed_schema_ids is None:
+        allowed_schema_ids = []
+
+    if allowed_otypes is None:
+        allowed_otypes = []
+
+    if time_from is None:
+        time_from = ""
+
+    if time_to is None:
+        time_to = ""
+
+    key_type = "fully_qualified_name" if isinstance(root_node.get("id"), str) and '.' in root_node.get("id") else "id"
+    return {
+        "processing_mode": processing_mode,
+        "show_temporal_objects": show_temporal_objects,
+        "design_time": design_time,
+        "max_depth": max_depth,
+        "allowed_schema_ids": allowed_schema_ids,
+        "allowed_otypes": allowed_otypes,
+        "time_from": time_from,
+        "time_to": time_to,
+        "key_type": key_type,
+    }

--- a/python/core-sdk/alation_ai_agent_sdk/lineage_filtering.py
+++ b/python/core-sdk/alation_ai_agent_sdk/lineage_filtering.py
@@ -1,4 +1,5 @@
-from typing import List, Dict, Set, TypedDict, Union
+from typing import List, Dict, Set, Union
+from typing_extensions import TypedDict
 
 OType = str
 class LineageGraphNode(TypedDict):

--- a/python/core-sdk/alation_ai_agent_sdk/lineage_filtering.py
+++ b/python/core-sdk/alation_ai_agent_sdk/lineage_filtering.py
@@ -1,8 +1,6 @@
 from typing import List, Dict, Set, TypedDict, Union
 
-type OType = str
-type AllowedOTypeSet = set[OType]
-
+OType = str
 class LineageGraphNode(TypedDict):
     fully_qualified_name: str
     id: Union[str, int]

--- a/python/core-sdk/alation_ai_agent_sdk/lineage_filtering.py
+++ b/python/core-sdk/alation_ai_agent_sdk/lineage_filtering.py
@@ -117,7 +117,7 @@ def filter_graph(nodes: List[Dict], allowed_types: Set[str]) -> List[Dict]:
         List[Dict]: The filtered list of nodes.
     """
     ordered_keys, key_to_node, visited = get_initial_graph_state(nodes)
-    
+
     # Populate the visited nodes and patch up neighbors to account for any that were omitted
     for node in nodes:
         resolve_neighbors(get_node_object_key(node), key_to_node, visited, allowed_types)

--- a/python/core-sdk/alation_ai_agent_sdk/lineage_filtering.py
+++ b/python/core-sdk/alation_ai_agent_sdk/lineage_filtering.py
@@ -12,10 +12,10 @@ class LineageGraphNode(TypedDict):
 def get_node_object_key(node: LineageGraphNode) -> str:
     """
     Returns a unique key for the node based on its type and ID.
-    
+
     Args:
         node (LineageGraphNode): The node to generate the key for.
-    
+
     Returns:
         str: A unique key for the node.
     """

--- a/python/core-sdk/alation_ai_agent_sdk/lineage_filtering.py
+++ b/python/core-sdk/alation_ai_agent_sdk/lineage_filtering.py
@@ -158,10 +158,10 @@ def build_filtered_graph(
         if "fully_qualified_name" in original_node:
             new_node["fully_qualified_name"] = original_node["fully_qualified_name"]
         new_node["neighbors"] = [
-            n for n in original_node["neighbors"] if get_node_object_key(n) in kept_keys
+            n for n in original_node.get("neighbors", []) if get_node_object_key(n) in kept_keys
         ]
         new_nodes.append(new_node)
-    # Each item in the list have have neighors but their neighbors are not allowed otherwise we're repeating
+    # Each item in the list have have neighbors but their neighbors are not allowed otherwise we're repeating
     # it in the nested structure at at the item list level.
     for node in new_nodes:
         if len(node["neighbors"]) == 0:
@@ -171,25 +171,3 @@ def build_filtered_graph(
                 del neighbor_node["neighbors"]
 
     return new_nodes
-
-"""
-# For testing purposes 
-graph = [
-    {"id": 1, "otype": "table", "fully_qualified_name": "1", "neighbors": [{"id": 2, "otype": "table", "fully_qualified_name": "2"}]},
-    {"id": 2, "otype": "table", "fully_qualified_name": "2", "neighbors": [{"id": 3, "otype": "etl", "fully_qualified_name": "3"}, {"id": 4, "otype": "table", "fully_qualified_name": "4"}]},
-    {"id": 3, "otype": "etl", "fully_qualified_name": "3", "neighbors": [{"id": 5, "otype": "table", "fully_qualified_name": "5"}]},
-    {"id": 4, "otype": "table", "fully_qualified_name": "4", "neighbors": []},
-    {"id": 5, "otype": "table", "fully_qualified_name": "5", "neighbors": []},
-    {"id": 6, "otype": "table", "fully_qualified_name": "6", "neighbors": [{"id": 3, "otype": "etl", "fully_qualified_name": "3"}]},
-    {"id": 7, "otype": "etl", "fully_qualified_name": "7", "neighbors": [{"id": 8, "otype": "etl", "fully_qualified_name": "8"}]},
-    {"id": 8, "otype": "etl", "fully_qualified_name": "8", "neighbors": []},
-    {"id": 9, "otype": "etl", "fully_qualified_name": "9", "neighbors": [{"id": 10, "otype": "table", "fully_qualified_name": "10"}]},
-    {"id": 10, "otype": "table", "fully_qualified_name": "10", "neighbors": []}
-]
-
-allowed = {"table"}
-filtered_graph = filter_graph(graph, allowed)
-
-import json
-print(json.dumps(filtered_graph, indent=2))
-"""

--- a/python/core-sdk/alation_ai_agent_sdk/lineage_filtering.py
+++ b/python/core-sdk/alation_ai_agent_sdk/lineage_filtering.py
@@ -1,0 +1,195 @@
+from typing import List, Dict, Set, TypedDict, Union
+
+type OType = str
+type AllowedOTypeSet = set[OType]
+
+class LineageGraphNode(TypedDict):
+    fully_qualified_name: str
+    id: Union[str, int]
+    otype: OType
+    neighbors: List['LineageGraphNode']
+
+
+def get_node_object_key(node: LineageGraphNode) -> str:
+    """
+    Returns a unique key for the node based on its type and ID.
+    
+    Args:
+        node (LineageGraphNode): The node to generate the key for.
+    
+    Returns:
+        str: A unique key for the node.
+    """
+    return f"{node['otype']}:{node['id']}"
+
+
+def get_initial_graph_state(
+    nodes: List[Dict],
+  ) -> tuple[List[str], Dict[str, Dict], Set[str]]:
+    """
+    Get the initial state of the graph from the list of nodes.
+
+    Args:
+        nodes (List[Dict]): The list of nodes to process.
+
+    Returns:
+        tuple[List[str], Dict[str, Dict], Set[str]]: A tuple containing:
+            - A list of ordered node keys.
+            - A mapping from node keys to their original node data.
+            - A set of visited node keys.
+    """
+    ordered_keys = []
+    key_to_node = {}
+    for node in nodes:
+        node_key = get_node_object_key(node)
+        key_to_node[node_key] = node
+        ordered_keys.append(node_key)
+    visited = {}
+    return (ordered_keys, key_to_node, visited)
+
+
+# Returns list of descendant nodes that are allowed (flattened and reattached)
+def resolve_neighbors(
+    node_key: str,
+    key_to_node: Dict[str, Dict],
+    visited: Dict[str, List[Dict]],
+    allowed_types: Set[str],
+) -> tuple[List[Dict], Dict[str, List[Dict]]]:
+    """
+    Resolves the neighbors of a given node, returning the allowed descendant nodes.
+
+    Args:
+        node_key (str): The key of the node to resolve neighbors for.
+        key_to_node (Dict[str, Dict]): A mapping from node keys to their original node data.
+        visited (Dict[str, List[Dict]]): A mapping of visited nodes and their descendants.
+        allowed_types (Set[str]): A set of allowed node types.
+
+    Returns:
+        tuple[List[Dict], Dict[str, List[Dict]]]: A tuple containing:
+            - A list of allowed descendant nodes.
+            - An updated mapping of visited nodes and their descendants.
+    """
+    if node_key in visited:
+        return (visited[node_key], visited)
+
+    node = key_to_node[node_key]
+    if node['otype'] in allowed_types:
+        new_neighbors = []
+        if "neighbors" not in node:
+            visited[node_key] = [key_to_node[node_key]]
+            return (new_neighbors, visited)
+
+        for neighbor_node in node["neighbors"]:
+            neighbor_key = get_node_object_key(neighbor_node)
+            neighbors_neighbors, visited = resolve_neighbors(neighbor_key, key_to_node, visited, allowed_types)
+            new_neighbors.extend(neighbors_neighbors)
+        visited[node_key] = [key_to_node[node_key]]
+        unique_new_neighbors = {get_node_object_key(n): n for n in new_neighbors}
+        node['neighbors'] = [
+            new_neighbor
+            for new_neighbor in new_neighbors
+            if get_node_object_key(new_neighbor) in unique_new_neighbors
+          ]
+        return ([key_to_node[node_key]], visited)
+
+    # Omit this node, but keep its children (recursively)
+    collected = []
+    if "neighbors" not in node:
+        visited[node_key] = collected
+        return (collected, visited)
+    for neighbor_node in node["neighbors"]:
+        neighbor_key = get_node_object_key(neighbor_node)
+        neighbors_neighbors, visited = resolve_neighbors(neighbor_key, key_to_node, visited, allowed_types)
+        collected.extend(neighbors_neighbors)
+    visited[node_key] = collected
+    return (collected, visited)
+
+
+def filter_graph(nodes: List[Dict], allowed_types: Set[str]) -> List[Dict]:
+    """
+    Filters the graph to only include nodes of allowed types and their descendants.
+    Maintains hierarchical relationships between nodes even when omitting some.
+
+    Args:
+        nodes (List[Dict]): The list of nodes to filter.
+        allowed_types (Set[str]): A set of allowed node types.
+
+    Returns:
+        List[Dict]: The filtered list of nodes.
+    """
+    ordered_keys, key_to_node, visited = get_initial_graph_state(nodes)
+    
+    # Populate the visited nodes and patch up neighbors to account for any that were omitted
+    for node in nodes:
+        resolve_neighbors(get_node_object_key(node), key_to_node, visited, allowed_types)
+    kept_keys = {node_key for node_key in visited if key_to_node[node_key]['otype'] in allowed_types}
+    # Free the memory before we build the filtered graph
+    visited = {}
+
+    new_nodes = build_filtered_graph(ordered_keys, kept_keys, key_to_node)
+    return new_nodes
+
+
+def build_filtered_graph(
+      ordered_keys: List[str],
+      kept_keys: Set[str],
+      key_to_node: Dict[str, Dict],
+) -> List[Dict]:
+    """
+    Builds the filtered graph from the ordered keys and kept keys.
+
+    Args:
+        ordered_keys (List[str]): The list of ordered node keys.
+        kept_keys (Set[str]): A set of kept node keys.
+        key_to_node (Dict[str, Dict]): A mapping from node keys to their original node data.
+
+    Returns:
+        List[Dict]: The filtered list of nodes which represent the lineage graph.
+    """
+    new_nodes = []
+    for node_key in ordered_keys:
+        if node_key not in kept_keys:
+            continue
+        original_node = key_to_node[node_key]
+        new_node = {
+            "id": original_node["id"],
+            "otype": original_node["otype"],
+        }
+        if "fully_qualified_name" in original_node:
+            new_node["fully_qualified_name"] = original_node["fully_qualified_name"]
+        new_node["neighbors"] = [
+            n for n in original_node["neighbors"] if get_node_object_key(n) in kept_keys
+        ]
+        new_nodes.append(new_node)
+    # Each item in the list have have neighors but their neighbors are not allowed otherwise we're repeating
+    # it in the nested structure at at the item list level.
+    for node in new_nodes:
+        if len(node["neighbors"]) == 0:
+            continue
+        for neighbor_node in node["neighbors"]:
+            if "neighbors" in neighbor_node:
+                del neighbor_node["neighbors"]
+
+    return new_nodes
+
+"""
+# For testing purposes 
+graph = [
+    {"id": 1, "otype": "table", "fully_qualified_name": "1", "neighbors": [{"id": 2, "otype": "table", "fully_qualified_name": "2"}]},
+    {"id": 2, "otype": "table", "fully_qualified_name": "2", "neighbors": [{"id": 3, "otype": "etl", "fully_qualified_name": "3"}, {"id": 4, "otype": "table", "fully_qualified_name": "4"}]},
+    {"id": 3, "otype": "etl", "fully_qualified_name": "3", "neighbors": [{"id": 5, "otype": "table", "fully_qualified_name": "5"}]},
+    {"id": 4, "otype": "table", "fully_qualified_name": "4", "neighbors": []},
+    {"id": 5, "otype": "table", "fully_qualified_name": "5", "neighbors": []},
+    {"id": 6, "otype": "table", "fully_qualified_name": "6", "neighbors": [{"id": 3, "otype": "etl", "fully_qualified_name": "3"}]},
+    {"id": 7, "otype": "etl", "fully_qualified_name": "7", "neighbors": [{"id": 8, "otype": "etl", "fully_qualified_name": "8"}]},
+    {"id": 8, "otype": "etl", "fully_qualified_name": "8", "neighbors": []},
+    {"id": 9, "otype": "etl", "fully_qualified_name": "9", "neighbors": [{"id": 10, "otype": "table", "fully_qualified_name": "10"}]},
+    {"id": 10, "otype": "table", "fully_qualified_name": "10", "neighbors": []}
+]
+
+allowed = {"table"}
+filtered_graph = filter_graph(graph, allowed)
+
+import json
+print(json.dumps(filtered_graph, indent=2))
+"""

--- a/python/core-sdk/alation_ai_agent_sdk/sdk.py
+++ b/python/core-sdk/alation_ai_agent_sdk/sdk.py
@@ -16,7 +16,7 @@ from .lineage import (
     LineageDirectionType,
     LineageDesignTimeType,
     LineageGraphProcessingType,
-    LineageAllowedSchemaIdsType,
+    LineageExcludedSchemaIdsType,
     LineageOTypeFilterType,
     LineageTimestampType,
     LineagePagination,
@@ -131,7 +131,7 @@ class AlationAIAgentSDK:
         show_temporal_objects: Optional[bool] = False,
         design_time: Optional[LineageDesignTimeType] = None,
         max_depth: Optional[int] = 10,
-        allowed_schema_ids: Optional[LineageAllowedSchemaIdsType] = None,
+        excluded_schema_ids: Optional[LineageExcludedSchemaIdsType] = None,
         allowed_otypes: Optional[LineageOTypeFilterType] = None,
         time_from: Optional[LineageTimestampType] = None,
         time_to: Optional[LineageTimestampType] = None,
@@ -149,7 +149,7 @@ class AlationAIAgentSDK:
             show_temporal_objects (bool, optional): Whether to include temporary objects in the lineage. Defaults to False.
             design_time (LineageDesignTimeType, optional): The design time option to filter lineage. Defaults to LineageDesignTimeOptions.EITHER_DESIGN_OR_RUN_TIME.
             max_depth (int, optional): The maximum depth to traverse in the lineage graph. Defaults to 10.
-            allowed_schema_ids (LineageAllowedSchemaIdsType, optional): A list of allowed schema IDs to filter lineage nodes. Defaults to None.
+            excluded_schema_ids (LineageExcludedSchemaIdsType, optional): A list of allowed schema IDs to filter lineage nodes. Defaults to None.
             allowed_otypes (LineageOTypeFilterType, optional): A list of allowed object types to filter lineage nodes. Defaults to None.
             time_from (LineageTimestampType, optional): The start time for temporal lineage filtering. Defaults to None.
             time_to (LineageTimestampType, optional): The end time for temporal lineage filtering. Defaults to None.
@@ -169,7 +169,7 @@ class AlationAIAgentSDK:
             show_temporal_objects=show_temporal_objects,
             design_time=design_time,
             max_depth=max_depth,
-            allowed_schema_ids=allowed_schema_ids,
+            excluded_schema_ids=excluded_schema_ids,
             allowed_otypes=allowed_otypes,
             time_from=time_from,
             time_to=time_to

--- a/python/core-sdk/alation_ai_agent_sdk/sdk.py
+++ b/python/core-sdk/alation_ai_agent_sdk/sdk.py
@@ -190,7 +190,7 @@ class AlationAIAgentSDK:
             allowed_otypes (LineageOTypeFilterType, optional): A list of allowed object types to filter lineage nodes. Defaults to None.
             time_from (LineageTimestampType, optional): The start time for temporal lineage filtering. Defaults to None.
             time_to (LineageTimestampType, optional): The end time for temporal lineage filtering. Defaults to None.
-        
+
         Returns:
             Dict[str, Dict[str, any]]]: A dictionary containing the lineage `graph` and `pagination` information.
 

--- a/python/core-sdk/alation_ai_agent_sdk/sdk.py
+++ b/python/core-sdk/alation_ai_agent_sdk/sdk.py
@@ -68,6 +68,7 @@ class AlationAIAgentSDK:
         if not auth_method or not isinstance(auth_method, str):
             raise ValueError("auth_method must be a non-empty string.")
 
+        self.beta_tools = {AlationTools.LINEAGE}
         self.disabled_tools = disabled_tools or set()
         self.enabled_beta_tools = enabled_beta_tools or set()
 
@@ -89,10 +90,7 @@ class AlationAIAgentSDK:
     def is_tool_enabled(self, tool_name: str) -> bool:
         if tool_name in self.disabled_tools:
             return False
-        if len(self.enabled_beta_tools) == 0:
-            return True
-        beta_tools = {AlationTools.LINEAGE}
-        if tool_name not in beta_tools:
+        if tool_name not in self.beta_tools:
             return True
         if tool_name in self.enabled_beta_tools:
             return True

--- a/python/core-sdk/alation_ai_agent_sdk/sdk.py
+++ b/python/core-sdk/alation_ai_agent_sdk/sdk.py
@@ -180,7 +180,6 @@ class AlationAIAgentSDK:
             limit=limit,
             batch_size=batch_size,
             pagination=pagination,
-            max_depth=max_depth
             **lineage_kwargs,
         )
 

--- a/python/core-sdk/alation_ai_agent_sdk/sdk.py
+++ b/python/core-sdk/alation_ai_agent_sdk/sdk.py
@@ -1,6 +1,14 @@
-from typing import Dict, Any, Optional
-
-from .api import AlationAPI, AlationAPIError, AuthParams, CatalogAssetMetadataPayloadItem
+from typing import (
+    Any,
+    Dict,
+    Optional,
+)
+from .api import (
+    AlationAPI,
+    AlationAPIError,
+    AuthParams,
+    CatalogAssetMetadataPayloadItem,
+)
 from .tools import (
     AlationContextTool,
     AlationBulkRetrievalTool,
@@ -69,6 +77,18 @@ class AlationAIAgentSDK:
         self.update_catalog_asset_metadata_tool = UpdateCatalogAssetMetadataTool(self.api)
         self.check_job_status_tool = CheckJobStatusTool(self.api)
         self.lineage_tool = AlationLineageTool(self.api)
+
+    def is_tool_enabled(self, tool_name: str) -> bool:
+        if tool_name in self.disabled_tools:
+            return False
+        if len(self.enabled_beta_tools) == 0:
+            return True
+        beta_tools = {AlationTools.LINEAGE}
+        if tool_name not in beta_tools:
+            return True
+        if tool_name in self.enabled_beta_tools:
+            return True
+        return False
 
     def set_enabled_beta_tools(self, tools: set[str]):
         self.enabled_beta_tools = tools
@@ -253,16 +273,16 @@ class AlationAIAgentSDK:
 
     def get_tools(self):
         tools = []
-        if not AlationTools.AGGREGATED_CONTEXT in self.disabled_tools:
+        if self.is_tool_enabled(AlationTools.AGGREGATED_CONTEXT):
             tools.append(self.context_tool)
-        if not AlationTools.BULK_RETRIEVAL in self.disabled_tools:
+        if self.is_tool_enabled(AlationTools.BULK_RETRIEVAL):
             tools.append(self.bulk_retrieval_tool)
-        if not AlationTools.DATA_PRODUCT in self.disabled_tools:
+        if self.is_tool_enabled(AlationTools.DATA_PRODUCT):
             tools.append(self.data_product_tool)
-        if not AlationTools.UPDATE_METADATA in self.disabled_tools:
+        if self.is_tool_enabled(AlationTools.UPDATE_METADATA):
             tools.append(self.update_catalog_asset_metadata_tool)
-        if not AlationTools.CHECK_JOB_STATUS in self.disabled_tools:
+        if self.is_tool_enabled(AlationTools.CHECK_JOB_STATUS):
             tools.append(self.check_job_status_tool)
-        if AlationTools.LINEAGE in self.enabled_beta_tools and not AlationTools.LINEAGE in self.disabled_tools:
+        if self.is_tool_enabled(AlationTools.LINEAGE):
             tools.append(self.get_lineage_tool)
         return tools

--- a/python/core-sdk/alation_ai_agent_sdk/sdk.py
+++ b/python/core-sdk/alation_ai_agent_sdk/sdk.py
@@ -281,5 +281,5 @@ class AlationAIAgentSDK:
         if self.is_tool_enabled(AlationTools.CHECK_JOB_STATUS):
             tools.append(self.check_job_status_tool)
         if self.is_tool_enabled(AlationTools.LINEAGE):
-            tools.append(self.get_lineage_tool)
+            tools.append(self.lineage_tool)
         return tools

--- a/python/core-sdk/alation_ai_agent_sdk/sdk.py
+++ b/python/core-sdk/alation_ai_agent_sdk/sdk.py
@@ -60,6 +60,7 @@ class AlationAIAgentSDK:
         disabled_tools: Optional[set[str]] = None,
         enabled_beta_tools: Optional[set[str]] = None,
         dist_version: Optional[str] = None,
+        skip_instance_info: Optional[bool] = False,
     ):
         if not base_url or not isinstance(base_url, str):
             raise ValueError("base_url must be a non-empty string.")
@@ -76,6 +77,7 @@ class AlationAIAgentSDK:
             auth_method=auth_method,
             auth_params=auth_params,
             dist_version=dist_version,
+            skip_instance_info=skip_instance_info,
         )
         self.context_tool = AlationContextTool(self.api)
         self.bulk_retrieval_tool = AlationBulkRetrievalTool(self.api)

--- a/python/core-sdk/alation_ai_agent_sdk/sdk.py
+++ b/python/core-sdk/alation_ai_agent_sdk/sdk.py
@@ -186,7 +186,7 @@ class AlationAIAgentSDK:
             show_temporal_objects (bool, optional): Whether to include temporary objects in the lineage. Defaults to False.
             design_time (LineageDesignTimeType, optional): The design time option to filter lineage. Defaults to LineageDesignTimeOptions.EITHER_DESIGN_OR_RUN_TIME.
             max_depth (int, optional): The maximum depth to traverse in the lineage graph. Defaults to 10.
-            excluded_schema_ids (LineageExcludedSchemaIdsType, optional): A list of allowed schema IDs to filter lineage nodes. Defaults to None.
+            excluded_schema_ids (LineageExcludedSchemaIdsType, optional): A list of excluded schema IDs to filter lineage nodes. Defaults to None.
             allowed_otypes (LineageOTypeFilterType, optional): A list of allowed object types to filter lineage nodes. Defaults to None.
             time_from (LineageTimestampType, optional): The start time for temporal lineage filtering. Defaults to None.
             time_to (LineageTimestampType, optional): The end time for temporal lineage filtering. Defaults to None.

--- a/python/core-sdk/alation_ai_agent_sdk/tools.py
+++ b/python/core-sdk/alation_ai_agent_sdk/tools.py
@@ -215,13 +215,15 @@ class AlationLineageTool:
         - Use optional parameters sparingly. Most of the defaults are suitable for common use cases. Use them when directed by the user or when the user's question warrants their specific inclusion.
 
     Parameters:
-        - `root_node`: The root node for the lineage query. Typically an object key consisting of the object ID and type. e.g. `{"id": 123, "type": "table"}`
+        - `root_node`: The root node for the lineage query. Typically this is an object key consisting of the object ID and type `{"id": 123, "otype": "table"}`.
+             However, certain otypes (`file`, `directory`, and `external`) require a fully qualified name for id.
+             A fully qualified name for those object types is the complete path to the file or directory prefixed by the filesystem id separated by a period like "<fileSystemId>.directory/to/filename". For filesystem id 2 and `file1` it would be `{"id": "2.root_folder/nested_folder/file1", "otype": "file"}`
         - `direction`: The direction of the lineage (upstream or downstream). Upstream objects can be related via a process or transformation or may represent the original source of the data. Downstream objects may be derived from the current object in some way.
         - `limit`: The maximum number of nodes to return. `limit` and `batch_size` should reuse the same value to avoid multiple round trips and the added assembly of several subgraphs unless in chunked processing mode. Hard upper limit of 1,000.
         - `batch_size`: The number of nodes to process in each batch.
         - `pagination`: Pagination information for the query. This should originate from an initial lineage response. Never generate a `pagination` parameter without having received one. It is okay to reuse one from the previous response when in 'chunked' processing mode.
-        - `processing_mode`: The processing mode for the query (complete or chunked). Only use the chunked processing mode for extremely large graphs (10,000+ nodes) and as a last resort.
-        - `show_temporal_objects`: Whether to show temporal objects. These tend to clutter graphs more than help. But can be included to show a more complete picture of the lineage.
+        - `processing_mode`: The processing mode for the query (complete or chunked). Only use the chunked processing mode when you wish to limit the response to smaller subgraphs.
+        - `show_temporal_objects`: Whether to show temporal objects. These tend to clutter graphs more than help but can be included to show a more complete picture of the lineage.
         - `design_time`: The design time option. Use 3 for nearly all cases. It includes objects created at either run time or design time. Use 1 for objects created during design time and use 2 for objects only created during run time.
         - `max_depth`: The maximum depth for the query. Default is 10.
         - `allowed_schema_ids`: The allowed schema IDs like: [1, 2, 3]. The graph will only include items that belong to these schemas.
@@ -233,11 +235,11 @@ class AlationLineageTool:
         - A dictionary containing the following keys: `graph`, `direction`, and `pagination`.
 
         USAGE EXAMPLES:
-        - Find all upstream objects for a given table: `get_lineage(root_node={"id": 123, "type": "table"},direction="upstream")`
-        - Find all downstream objects for a given table: `get_lineage(root_node={"id": 123, "type": "table"},direction="downstream")`
-        - Find all upstream table objects for a given table: `get_lineage(root_node={"id": 123, "type": "table"},direction="upstream",allowed_otypes=["table"])`
-        - Find all downstream column objects for a given column: `get_lineage(root_node={"id": 123, "type": "attribute"},direction="downstream",allowed_otypes=["attribute"])`
-        - Find all upstream objects for a given table including temporal objects: `get_lineage(root_node={"id": 123, "type": "table"},direction="upstream",show_temporal_objects=True)`
+        - Find all upstream objects for a given table: `get_lineage(root_node={"id": 123, "otype": "table"}, direction="upstream")`
+        - Find all downstream objects for a given table: `get_lineage(root_node={"id": 123, "otype": "table"}, direction="downstream")`
+        - Find all upstream table objects for a given table: `get_lineage(root_node={"id": 123, "otype": "table"}, direction="upstream", allowed_otypes=["table"])`
+        - Find all downstream column objects for a given column / attribute: `get_lineage(root_node={"id": 123, "otype": "attribute"}, direction="downstream", allowed_otypes=["attribute"])`
+        - Find all upstream objects for a given table including temporal objects: `get_lineage(root_node={"id": 123, "otype": "table"}, direction="upstream", show_temporal_objects=True)`
         """
 
     def run(

--- a/python/core-sdk/alation_ai_agent_sdk/tools.py
+++ b/python/core-sdk/alation_ai_agent_sdk/tools.py
@@ -217,14 +217,14 @@ class AlationLineageTool:
     Parameters:
         - `root_node`: The root node for the lineage query. Typically an object key consisting of the object ID and type. e.g. `{"id": 123, "type": "table"}`
         - `direction`: The direction of the lineage (upstream or downstream). Upstream objects can be related via a process or transformation or may represent the original source of the data. Downstream objects may be derived from the current object in some way.
-        - `limit`: The maximum number of nodes to return. `limit` and `batch_size` should reuse the same value to avoid multiple round trips and the added assembly of several subgraphs unless in chunked processing mode.
+        - `limit`: The maximum number of nodes to return. `limit` and `batch_size` should reuse the same value to avoid multiple round trips and the added assembly of several subgraphs unless in chunked processing mode. Hard upper limit of 1,000.
         - `batch_size`: The number of nodes to process in each batch.
         - `pagination`: Pagination information for the query. This should originate from an initial lineage response. Never generate a `pagination` parameter without having received one. It is okay to reuse one from the previous response when in 'chunked' processing mode.
         - `processing_mode`: The processing mode for the query (complete or chunked). Only use the chunked processing mode for extremely large graphs (10,000+ nodes) and as a last resort.
         - `show_temporal_objects`: Whether to show temporal objects. These tend to clutter graphs more than help. But can be included to show a more complete picture of the lineage.
         - `design_time`: The design time option. Use 3 for nearly all cases. It includes objects created at either run time or design time. Use 1 for objects created during design time and use 2 for objects only created during run time.
         - `max_depth`: The maximum depth for the query. Default is 10.
-        - `allowed_schema_ids`: The allowed schema IDs like: [1, 2, 3].
+        - `allowed_schema_ids`: The allowed schema IDs like: [1, 2, 3]. The graph will only include items that belong to these schemas.
         - `allowed_otypes`: The allowed object types. Pass values as strings like: ["table"].
         - `time_from`: The start time (timestamp) for the query.
         - `time_to`: The end time (timestamp) for the query.
@@ -276,7 +276,6 @@ class AlationLineageTool:
                 limit=limit,
                 batch_size=batch_size,
                 pagination=pagination,
-                max_depth=max_depth,
                 **lineage_kwargs
             )
         except AlationAPIError as e:

--- a/python/core-sdk/alation_ai_agent_sdk/tools.py
+++ b/python/core-sdk/alation_ai_agent_sdk/tools.py
@@ -279,7 +279,7 @@ class AlationLineageTool:
 
         COMMON OPTIONAL PARAMETERS:
         - allowed_otypes: Filter to specific object types like ["table", "attribute"]
-        - limit: Maximum nodes to return (default: 1000, max: 1000)
+        - limit: Maximum nodes to return (default: 1000, max: 1000). Never change this unless the user question explicitly mentions a limit.
         - max_depth: How many levels deep to traverse (default: 10)
 
         PROCESSING CONTROL:
@@ -305,7 +305,12 @@ class AlationLineageTool:
         - Exclude test schemas: get_lineage(root_node={"id": 123, "otype": "table"}, direction="upstream", excluded_schema_ids=[999, 1000])
 
         RETURNS:
-        {"graph": [list of connected objects with relationships], "direction": "upstream|downstream", "pagination": {...}}"""
+        {"graph": [list of connected objects with relationships], "direction": "upstream|downstream", "pagination": {...}}
+
+        HANDLING RESPONSES:
+        - Skip any temporary nodes unless the user question explicitly mentions them
+        - Fully qualified names should be split into their component parts (period separated). The last element is the most specific name.
+        """
 
     def run(
         self,

--- a/python/core-sdk/alation_ai_agent_sdk/tools.py
+++ b/python/core-sdk/alation_ai_agent_sdk/tools.py
@@ -370,7 +370,7 @@ class CheckJobStatusTool:
     def run(self, job_id: int) -> dict:
         return self.api.check_job_status(job_id)
 
-def env_to_tool_list(tool_env_var: Optional[str] = None) -> List[str]:
+def csv_str_to_tool_list(tool_env_var: Optional[str] = None) -> List[str]:
     if tool_env_var is None:
         return []
     tools = []

--- a/python/core-sdk/alation_ai_agent_sdk/tools.py
+++ b/python/core-sdk/alation_ai_agent_sdk/tools.py
@@ -4,7 +4,7 @@ from alation_ai_agent_sdk.api import AlationAPI, AlationAPIError, CatalogAssetMe
 from alation_ai_agent_sdk.lineage import (
     LineageBatchSizeType,
     LineageDesignTimeType,
-    LineageAllowedSchemaIdsType,
+    LineageExcludedSchemaIdsType,
     LineageTimestampType,
     LineageDirectionType,
     LineageGraphProcessingType,
@@ -224,7 +224,7 @@ class AlationLineageTool:
         - `show_temporal_objects`: Whether to show temporal objects. These tend to clutter graphs more than help but can be included to show a more complete picture of the lineage.
         - `design_time`: The design time option. Use 3 for nearly all cases. It includes objects created at either run time or design time. Use 1 for objects created during design time and use 2 for objects only created during run time.
         - `max_depth`: The maximum depth for the query. Default is 10.
-        - `allowed_schema_ids`: The allowed schema IDs like: [1, 2, 3]. The graph will only include items that belong to these schemas.
+        - `excluded_schema_ids`: The excluded schema IDs like: [1, 2, 3]. The graph will omit items which belong to these schemas.
         - `allowed_otypes`: The allowed object types. Pass values as strings like: ["table"].
         - `time_from`: The start time (timestamp) for the query.
         - `time_to`: The end time (timestamp) for the query.
@@ -251,7 +251,7 @@ class AlationLineageTool:
         show_temporal_objects: Optional[bool] = False,
         design_time: Optional[LineageDesignTimeType] = None,
         max_depth: Optional[int] = 10,
-        allowed_schema_ids: Optional[LineageAllowedSchemaIdsType] = None,
+        excluded_schema_ids: Optional[LineageExcludedSchemaIdsType] = None,
         allowed_otypes: Optional[LineageOTypeFilterType] = None,
         time_from: Optional[LineageTimestampType] = None,
         time_to: Optional[LineageTimestampType] = None,
@@ -263,7 +263,7 @@ class AlationLineageTool:
             show_temporal_objects=show_temporal_objects,
             design_time=design_time,
             max_depth=max_depth,
-            allowed_schema_ids=allowed_schema_ids,
+            excluded_schema_ids=excluded_schema_ids,
             allowed_otypes=allowed_otypes,
             time_from=time_from,
             time_to=time_to

--- a/python/core-sdk/alation_ai_agent_sdk/tools.py
+++ b/python/core-sdk/alation_ai_agent_sdk/tools.py
@@ -426,6 +426,7 @@ class CheckJobStatusTool:
     def run(self, job_id: int) -> dict:
         return self.api.check_job_status(job_id)
 
+# TODO: add new test
 def csv_str_to_tool_list(tool_env_var: Optional[str] = None) -> List[str]:
     if tool_env_var is None:
         return []

--- a/python/core-sdk/alation_ai_agent_sdk/tools.py
+++ b/python/core-sdk/alation_ai_agent_sdk/tools.py
@@ -1,6 +1,14 @@
-from typing import Dict, Any, Optional
-
-from alation_ai_agent_sdk.api import AlationAPI, AlationAPIError, CatalogAssetMetadataPayloadItem
+from typing import (
+    Any,
+    Dict,
+    List,
+    Optional,
+)
+from alation_ai_agent_sdk.api import (
+    AlationAPI,
+    AlationAPIError,
+    CatalogAssetMetadataPayloadItem,
+)
 from alation_ai_agent_sdk.lineage import (
     LineageBatchSizeType,
     LineageDesignTimeType,
@@ -361,3 +369,13 @@ class CheckJobStatusTool:
 
     def run(self, job_id: int) -> dict:
         return self.api.check_job_status(job_id)
+
+def env_to_tool_list(tool_env_var: Optional[str] = None) -> List[str]:
+    if tool_env_var is None:
+        return []
+    tools = []
+    if tool_env_var:
+        for tool_str in tool_env_var.split(","):
+            tool_str = tool_str.strip()
+            tools.append(tool_str)
+    return tools

--- a/python/core-sdk/alation_ai_agent_sdk/tools.py
+++ b/python/core-sdk/alation_ai_agent_sdk/tools.py
@@ -426,13 +426,12 @@ class CheckJobStatusTool:
     def run(self, job_id: int) -> dict:
         return self.api.check_job_status(job_id)
 
-# TODO: add new test
 def csv_str_to_tool_list(tool_env_var: Optional[str] = None) -> List[str]:
     if tool_env_var is None:
         return []
-    tools = []
+    uniq = set()
     if tool_env_var:
         for tool_str in tool_env_var.split(","):
             tool_str = tool_str.strip()
-            tools.append(tool_str)
-    return tools
+            uniq.add(tool_str)
+    return list(uniq)

--- a/python/core-sdk/pdm.lock
+++ b/python/core-sdk/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:4983bc5f21354859a9ed704a3f0f17186fca101df252a0b0a10d81964bd23384"
+content_hash = "sha256:2ceb10c8b00227ed3e34ed5bf52c23edae58e13ca9243d8671089ae9f8adcfc9"
 
 [[metadata.targets]]
 requires_python = ">=3.10"
@@ -274,14 +274,13 @@ files = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.14.0"
+version = "4.14.1"
 requires_python = ">=3.9"
 summary = "Backported and Experimental Type Hints for Python 3.9+"
-groups = ["dev"]
-marker = "python_version < \"3.11\""
+groups = ["default", "dev"]
 files = [
-    {file = "typing_extensions-4.14.0-py3-none-any.whl", hash = "sha256:a1514509136dd0b477638fc68d6a91497af5076466ad0fa6c338e44e359944af"},
-    {file = "typing_extensions-4.14.0.tar.gz", hash = "sha256:8676b788e32f02ab42d9e7c61324048ae4c6d844a399eebace3d4979d75ceef4"},
+    {file = "typing_extensions-4.14.1-py3-none-any.whl", hash = "sha256:d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76"},
+    {file = "typing_extensions-4.14.1.tar.gz", hash = "sha256:38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36"},
 ]
 
 [[package]]

--- a/python/core-sdk/pyproject.toml
+++ b/python/core-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "alation-ai-agent-sdk"
-version = "0.4.0"
+version = "0.5.0"
 description = "Alation Agent SDK"
 authors = [
   { name="Jagannath (Jags) Saragadam", email="jags.saragadam@alation.com"},

--- a/python/core-sdk/pyproject.toml
+++ b/python/core-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "alation-ai-agent-sdk"
-version = "0.5.0"
+version = "0.6.0"
 description = "Alation Agent SDK"
 authors = [
   { name="Jagannath (Jags) Saragadam", email="jags.saragadam@alation.com"},

--- a/python/core-sdk/pyproject.toml
+++ b/python/core-sdk/pyproject.toml
@@ -15,7 +15,8 @@ maintainers = [
   { name="Adam Talmadge", email="adam.talmadge@alation.com"},
 ]
 dependencies = [
-  "requests~=2.32.0"
+  "requests~=2.32.0",
+  "typing_extensions~=4.14.1",
 ]
 requires-python = ">=3.10"
 readme = "README.md"

--- a/python/core-sdk/tests/test_lineage.py
+++ b/python/core-sdk/tests/test_lineage.py
@@ -1,0 +1,596 @@
+import pytest
+from unittest.mock import (
+    MagicMock,
+    Mock,
+    patch,
+)
+from alation_ai_agent_sdk.lineage import (
+    LineageDesignTimeOptions,
+    LineageGraphProcessingOptions,
+    make_lineage_kwargs,
+)
+from alation_ai_agent_sdk.lineage_filtering import (
+    get_node_object_key,
+    get_initial_graph_state,
+    resolve_neighbors,
+    filter_graph,
+    build_filtered_graph,
+)
+from alation_ai_agent_sdk.tools import AlationLineageTool
+from alation_ai_agent_sdk.api import (
+    AlationAPI,
+    AlationAPIError,
+    UserAccountAuthParams,
+)
+
+def test_make_lineage_kwargs_creates_defaults():
+    response = make_lineage_kwargs(
+      root_node={"id": 1, "otype": "table"}
+    )
+    assert response["processing_mode"] == LineageGraphProcessingOptions.COMPLETE
+    assert response["show_temporal_objects"] == False
+    assert response["design_time"] == LineageDesignTimeOptions.EITHER_DESIGN_OR_RUN_TIME
+    assert response["max_depth"] == 10
+    assert response["allowed_schema_ids"] == []
+    assert response["allowed_otypes"] == []
+    assert response["time_from"] == ""
+    assert response["time_to"] == ""
+    assert response["key_type"] == "id"
+
+def test_make_lineage_kwargs_recognizes_fully_qualified_name_as_key_type():
+    response = make_lineage_kwargs(
+      root_node={"id": "1.my_schema.my_table", "otype": "table"}
+    )
+    assert response["key_type"] == "fully_qualified_name"
+
+def test_make_lineage_kwargs_respects_provided_values():
+    expected_max_depth = 22
+    expected_allowed_schema_ids = [1, 2]
+    expected_allowed_otypes = ["table"]
+    expected_processing_mode = LineageGraphProcessingOptions.CHUNKED
+    expected_design_time = LineageDesignTimeOptions.ONLY_DESIGN_TIME
+    response = make_lineage_kwargs(
+      root_node={"id": 1, "otype": "table"},
+      max_depth=expected_max_depth,
+      allowed_schema_ids=expected_allowed_schema_ids,
+      allowed_otypes=expected_allowed_otypes,
+      processing_mode=expected_processing_mode,
+      design_time=expected_design_time
+    )
+    assert response["max_depth"] == expected_max_depth
+    assert response["allowed_schema_ids"] == expected_allowed_schema_ids
+    assert response["allowed_otypes"] == expected_allowed_otypes
+    assert response["processing_mode"] == expected_processing_mode
+    assert response["design_time"] == expected_design_time
+
+def test_get_node_object_key():
+    response = get_node_object_key({"id": 1, "otype": "table"})
+    assert response == "table:1"
+
+def test_get_initial_graph_state():
+    graph_nodes_from_response = [
+        {
+            "id": 1,
+            "otype": "table",
+            "neighbors": [
+                {
+                    "id": 2,
+                    "otype": "table"
+                }
+            ]
+        },
+        {
+            "id": 2,
+            "otype": "table"
+        }
+    ]
+    expected_ordered_keys = [get_node_object_key(graph_nodes_from_response[0]), get_node_object_key(graph_nodes_from_response[1])]
+    ordered_keys, key_to_node, visited = get_initial_graph_state(graph_nodes_from_response)
+    assert expected_ordered_keys == ordered_keys
+    assert len(key_to_node) == 2
+    node1_obj_key = get_node_object_key(graph_nodes_from_response[0])
+    node2_obj_key = get_node_object_key(graph_nodes_from_response[1])
+    assert node1_obj_key in key_to_node
+    assert node2_obj_key in key_to_node
+    assert key_to_node[node1_obj_key] == graph_nodes_from_response[0]
+    assert key_to_node[node2_obj_key] == graph_nodes_from_response[1]
+    assert visited is not None
+    assert len(visited) == 0
+    assert isinstance(visited, dict)
+
+def test_resolve_neighbors_unvisited_allowed_node_no_neighbors():
+    node = {
+        "id": 1,
+        "otype": "table"
+    }
+    node_key = get_node_object_key(node)
+    visited = {}
+    key_to_node = {
+        node_key: node,
+    }
+    descendant_nodes, visited = resolve_neighbors(node_key=node_key, visited=visited, key_to_node=key_to_node, allowed_types={"table"})
+    assert descendant_nodes == []
+    assert visited == {node_key: [node]}
+
+def test_resolve_neighbors_unvisited_omitted_node_no_neighbors():
+    node = {
+        "id": 1,
+        "otype": "dataflow"
+    }
+    node_key = get_node_object_key(node)
+    visited = {}
+    key_to_node = {
+        node_key: node,
+    }
+    descendant_nodes, visited = resolve_neighbors(node_key=node_key, visited=visited, key_to_node=key_to_node, allowed_types={"view"})
+    assert descendant_nodes == []
+    assert visited == {node_key: []}
+
+def test_resolve_neighbors_unvisited_allowed_node_with_neighbors():
+    node2 = {
+        "id": 2,
+        "otype": "table"
+    }
+    node1 = {
+        "id": 1,
+        "otype": "table",
+        "neighbors": [
+            node2
+        ]
+    }
+    node1_key = get_node_object_key(node1)
+    node2_key = get_node_object_key(node2)
+
+    visited = {}
+    key_to_node = {
+        node1_key: node1,
+        node2_key: node2
+    }
+    descendant_nodes, visited = resolve_neighbors(node_key=node1_key, visited=visited, key_to_node=key_to_node, allowed_types={"table"})
+    assert descendant_nodes == [node1]
+    assert visited == {node1_key: [node1], node2_key: [node2]}
+
+def test_resolve_neighbors_unvisited_omitted_node_with_neighbors():
+    node2 = {
+        "id": 2,
+        "otype": "table"
+    }
+    node1 = {
+        "id": 1,
+        "otype": "dataflow",
+        "neighbors": [
+            node2
+        ]
+    }
+    node1_key = get_node_object_key(node1)
+    node2_key = get_node_object_key(node2)
+
+    visited = {}
+    key_to_node = {
+        node1_key: node1,
+        node2_key: node2
+    }
+    descendant_nodes, visited = resolve_neighbors(node_key=node1_key, visited=visited, key_to_node=key_to_node, allowed_types={"table"})
+    assert descendant_nodes == []
+    assert visited == {node2_key: [node2], node1_key: []}
+
+def test_resolve_neighbors_visited_allowed_node():
+    node = {
+        "id": 1,
+        "otype": "table",
+    }
+    node_key = get_node_object_key(node)
+    key_to_node = {
+        node_key: node,
+    }
+    orig_visited = {
+        node_key: [node],
+    }
+    descendant_nodes, visited = resolve_neighbors(node_key=node_key, visited=orig_visited, key_to_node=key_to_node, allowed_types={"table"})
+    assert descendant_nodes == [node]
+    assert visited == orig_visited  # Should not change visited state
+
+def test_resolve_neighbors_visited_omitted_node():
+    node = {
+        "id": 1,
+        "otype": "dataflow",
+    }
+    node_key = get_node_object_key(node)
+    key_to_node = {
+        node_key: node,
+    }
+    orig_visited = {
+        node_key: [],
+    }
+    descendant_nodes, visited = resolve_neighbors(node_key=node_key, visited=orig_visited, key_to_node=key_to_node, allowed_types={"table"})
+    assert descendant_nodes == []
+    assert visited == orig_visited  # Should not change visited state
+
+def test_filter_graph_basic():
+    graph_nodes = [
+        {
+            "id": 1,
+            "otype": "table",
+            "neighbors": [
+                {"id": 2, "otype": "table"},
+                {"id": 3, "otype": "dataflow"}
+            ]
+        },
+        {
+            "id": 2,
+            "otype": "table"
+        },
+        {
+            "id": 3,
+            "otype": "dataflow"
+        }
+    ]
+    allowed_types = {"table"}
+    filtered_graph = filter_graph(nodes=graph_nodes, allowed_types=allowed_types)
+    assert len(filtered_graph) == 2  # Only table nodes should remain
+    assert all(node["otype"] == "table" for node in filtered_graph)
+    assert filtered_graph[0]["id"] == 1
+    assert filtered_graph[1]["id"] == 2
+
+def test_filter_graph_nested():
+    graph_nodes = [
+      {"id": 1, "otype": "table", "fully_qualified_name": "1", "neighbors": [{"id": 2, "otype": "table", "fully_qualified_name": "2"}]},
+      {"id": 2, "otype": "table", "fully_qualified_name": "2", "neighbors": [{"id": 3, "otype": "etl", "fully_qualified_name": "3"}, {"id": 4, "otype": "table", "fully_qualified_name": "4"}]},
+      {"id": 3, "otype": "etl", "fully_qualified_name": "3", "neighbors": [{"id": 5, "otype": "table", "fully_qualified_name": "5"}]},
+      {"id": 4, "otype": "table", "fully_qualified_name": "4", "neighbors": []},
+      {"id": 5, "otype": "table", "fully_qualified_name": "5", "neighbors": []},
+      {"id": 6, "otype": "table", "fully_qualified_name": "6", "neighbors": [{"id": 3, "otype": "etl", "fully_qualified_name": "3"}]},
+      {"id": 7, "otype": "etl", "fully_qualified_name": "7", "neighbors": [{"id": 8, "otype": "etl", "fully_qualified_name": "8"}]},
+      {"id": 8, "otype": "etl", "fully_qualified_name": "8", "neighbors": []},
+      {"id": 9, "otype": "etl", "fully_qualified_name": "9", "neighbors": [{"id": 10, "otype": "table", "fully_qualified_name": "10"}]},
+      {"id": 10, "otype": "table", "fully_qualified_name": "10", "neighbors": []}
+    ]
+    allowed_types = {"table"}
+    filtered_graph = filter_graph(nodes=graph_nodes, allowed_types=allowed_types)
+    assert len(filtered_graph) == 6  # Only table nodes should remain
+    assert all(node["otype"] == "table" for node in filtered_graph)
+    assert filtered_graph[0]["id"] == graph_nodes[0]["id"]
+    assert filtered_graph[1]["id"] == graph_nodes[1]["id"]
+    assert filtered_graph[2]["id"] == graph_nodes[3]["id"]
+    assert filtered_graph[3]["id"] == graph_nodes[4]["id"]
+    assert filtered_graph[4]["id"] == graph_nodes[5]["id"]
+    assert filtered_graph[5]["id"] == graph_nodes[9]["id"]
+
+def test_build_filtered_graph():
+    ordered_keys = ["table:1", "table:2", "dataflow:3", "fake_type:5"]
+    kept_keys = {"table:1", "table:2"}
+    key_to_node = {
+        "table:1": {"id": 1, "otype": "table", "neighbors": [{"id": 2, "otype": "table", "neighbors": [{"id": 4, "otype": "throw_away"}]}]},
+        "table:2": {"id": 2, "otype": "table"},
+        "dataflow:3": {"id": 3, "otype": "dataflow"}
+    }
+    filtered_graph = build_filtered_graph(ordered_keys, kept_keys, key_to_node)
+    assert len(filtered_graph) == 2
+    assert filtered_graph[0]["id"] == 1
+    assert filtered_graph[0]["otype"] == "table"
+    assert filtered_graph[0]["neighbors"] == [{"id": 2, "otype": "table"}]
+    assert filtered_graph[1]["id"] == 2
+    assert filtered_graph[1]["otype"] == "table"
+    assert filtered_graph[1]["neighbors"] == []
+
+
+@pytest.fixture
+def mock_api():
+    """Creates a mock AlationAPI for testing."""
+    return Mock()
+
+@pytest.fixture
+def get_lineage_tool(mock_api):
+    """Creates an AlationLineageTool with mock API."""
+    return AlationLineageTool(mock_api)
+
+def test_alation_lineage_tool_should_invoke_make_lineage_kwargs(get_lineage_tool):
+    with patch("alation_ai_agent_sdk.tools.make_lineage_kwargs") as mock_make_lineage_kwargs:
+        get_lineage_tool.run(
+            root_node={
+                "id": 1,
+                "otype": "table",
+            },
+            direction="downstream"
+        )
+        mock_make_lineage_kwargs.assert_called_once()
+
+
+def test_alation_lineage_tool_returns_api_errors(get_lineage_tool, mock_api):
+    # Mock API error
+    api_error = AlationAPIError(
+        message="Bad Request",
+        status_code=400,
+        reason="Bad Request",
+        resolution_hint="Check API parameters"
+    )
+    mock_api.get_bulk_lineage.side_effect = api_error
+    result = get_lineage_tool.run(
+        root_node={"id": 1, "otype": "table"},
+        direction="downstream",
+        limit=100,
+        batch_size=100,
+    )
+    mock_api.get_bulk_lineage.assert_called_once()
+    # Verify error handling
+    assert "error" in result
+    assert result["error"]["message"] == "Bad Request"
+    assert result["error"]["status_code"] == 400
+    assert result["error"]["reason"] == "Bad Request"
+
+
+def test_alation_lineage_tool_raises_value_errors_during_validation():
+    api = AlationAPI(
+        base_url="https://api.alation.com",
+        auth_method="user_account",
+        auth_params=UserAccountAuthParams(
+            111,
+            refresh_token="mock-refresh-token"
+        )
+    )
+    with pytest.raises(ValueError) as ex:
+        api.get_bulk_lineage(
+            root_nodes=[{"id": 1, "otype": "table"}],
+            direction="downstream",
+            limit=10000,
+            batch_size=10000,
+            processing_mode=LineageGraphProcessingOptions.COMPLETE,
+            allowed_otypes=None,
+            allowed_schema_ids=None,
+            max_depth=1000,
+            show_temporal_objects=False,
+            key_type="id",
+            design_time=LineageDesignTimeOptions.EITHER_DESIGN_OR_RUN_TIME,
+            time_from="",
+            time_to="",
+            pagination=None,
+        )
+    assert "limit cannot exceed" in str(ex.value)
+    with pytest.raises(ValueError) as ex:
+        api.get_bulk_lineage(
+            root_nodes=[{"id": 1, "otype": "table"}],
+            limit=1000,
+            batch_size=1000,
+            direction="downstream",
+            allowed_otypes=[],
+            processing_mode=LineageGraphProcessingOptions.COMPLETE,
+            allowed_schema_ids=None,
+            max_depth=1000,
+            show_temporal_objects=False,
+            key_type="id",
+            design_time=LineageDesignTimeOptions.EITHER_DESIGN_OR_RUN_TIME,
+            time_from="",
+            time_to="",
+            pagination=None,
+        )
+    assert "cannot be empty list" in str(ex.value)
+    with pytest.raises(ValueError) as ex:
+        api.get_bulk_lineage(
+            root_nodes=[{"id": 1, "otype": "table"}],
+            direction="downstream",
+            limit=1000,
+            batch_size=1000,
+            allowed_otypes=["table"],
+            processing_mode=LineageGraphProcessingOptions.CHUNKED,
+            allowed_schema_ids=None,
+            max_depth=1000,
+            show_temporal_objects=False,
+            key_type="id",
+            design_time=LineageDesignTimeOptions.EITHER_DESIGN_OR_RUN_TIME,
+            time_from="",
+            time_to="",
+            pagination=None,
+        )
+    assert "only supported in 'complete' processing mode" in str(ex.value)
+    with pytest.raises(ValueError) as ex:
+        api.get_bulk_lineage(
+            root_nodes=[{"id": 1, "otype": "table"}],
+            direction="downstream",
+            limit=1000,
+            batch_size=1000,
+            allowed_otypes=["table"],
+            processing_mode=LineageGraphProcessingOptions.COMPLETE,
+            pagination={
+                "request_id": "123",
+                "batch_size": 1000,
+                "cursor": 123,
+                "has_more": True
+            },
+            allowed_schema_ids=None,
+            max_depth=1000,
+            show_temporal_objects=False,
+            key_type="id",
+            design_time=LineageDesignTimeOptions.EITHER_DESIGN_OR_RUN_TIME,
+            time_from="",
+            time_to="",
+        )
+    assert "only supported in 'chunked' processing mode" in str(ex.value)
+        
+
+
+@pytest.fixture
+def mock_requests_post(monkeypatch):
+    """Mocks requests.post for API calls."""
+    mock_post_responses = {}
+
+    def _add_mock_response(url_identifier, response_json=None, status_code=200):
+        mock_post_responses[url_identifier] = {
+            "response_json": response_json,
+            "status_code": status_code,
+        }
+
+    def mock_post_router(*args, **kwargs):
+        url = args[0]
+        print(f"Intercepting POST request to URL: {url}")
+        print(f"Request body: {kwargs.get('json', {})}")
+        for identifier, mock_response in mock_post_responses.items():
+            if identifier in url:
+                print(f"Mocking response for URL: {url}")
+                response_mock = MagicMock()
+                response_mock.status_code = mock_response["status_code"]
+                response_mock.json.return_value = mock_response["response_json"]
+                return response_mock
+        raise ValueError(f"No mock response found for URL: {url}")
+
+    monkeypatch.setattr("requests.post", mock_post_router)
+    return _add_mock_response
+
+@pytest.fixture
+def alation_api():
+    """Fixture to initialize AlationAPI instance."""
+    api = AlationAPI(
+        base_url="https://api.alation.com",
+        auth_method="user_account",
+        auth_params=UserAccountAuthParams(
+            111,
+            refresh_token="mock-refresh-token"
+        )
+    )
+    api.access_token = "mock-access-token"
+    return api
+
+@pytest.fixture
+def mock_token_methods(monkeypatch):
+    """Mocks token validation and generation methods."""
+    monkeypatch.setattr(
+        "alation_ai_agent_sdk.api.AlationAPI._is_access_token_valid",
+        lambda self: True,
+    )
+    monkeypatch.setattr(
+        "alation_ai_agent_sdk.api.AlationAPI._generate_access_token_with_refresh_token",
+        lambda self: None,
+    )
+    monkeypatch.setattr(
+        "alation_ai_agent_sdk.api.AlationAPI._generate_jwt_token",
+        lambda self: None,
+    )
+
+
+def test_get_bulk_lineage_success_complete_filtered_with_pagination_response(alation_api, mock_requests_post, mock_token_methods):
+    graph_nodes = [
+      {"id": 1, "otype": "table", "fully_qualified_name": "1", "neighbors": [{"id": 2, "otype": "table", "fully_qualified_name": "2"}]},
+      {"id": 2, "otype": "table", "fully_qualified_name": "2", "neighbors": [{"id": 3, "otype": "etl", "fully_qualified_name": "3"}, {"id": 4, "otype": "table", "fully_qualified_name": "4"}]},
+      {"id": 3, "otype": "etl", "fully_qualified_name": "3", "neighbors": [{"id": 5, "otype": "table", "fully_qualified_name": "5"}]},
+      {"id": 4, "otype": "table", "fully_qualified_name": "4", "neighbors": []},
+      {"id": 5, "otype": "table", "fully_qualified_name": "5", "neighbors": []},
+      {"id": 6, "otype": "table", "fully_qualified_name": "6", "neighbors": [{"id": 3, "otype": "etl", "fully_qualified_name": "3"}]},
+      {"id": 7, "otype": "etl", "fully_qualified_name": "7", "neighbors": [{"id": 8, "otype": "etl", "fully_qualified_name": "8"}]},
+      {"id": 8, "otype": "etl", "fully_qualified_name": "8", "neighbors": []},
+      {"id": 9, "otype": "etl", "fully_qualified_name": "9", "neighbors": [{"id": 10, "otype": "table", "fully_qualified_name": "10"}]},
+      {"id": 10, "otype": "table", "fully_qualified_name": "10", "neighbors": []}
+    ]
+    mock_requests_post(
+        "/bulk_lineage",
+        response_json=
+            {
+                "graph": graph_nodes,
+                "direction": "upstream",
+                "request_id": "123",
+                "Pagination": {
+                    "cursor": 123,
+                    "has_more": True,
+                    "batch_size": 1000,
+                }
+            },
+        status_code=200,
+    )
+    result = alation_api.get_bulk_lineage(
+        root_nodes=[{"id": 1, "otype": "table"}],
+        direction="upstream",
+        limit=1000,
+        batch_size=1000,
+        processing_mode=LineageGraphProcessingOptions.COMPLETE,
+        show_temporal_objects=False,
+        design_time=LineageDesignTimeOptions.EITHER_DESIGN_OR_RUN_TIME,
+        max_depth=10,
+        allowed_schema_ids=None,
+        allowed_otypes=["table"],
+        time_from="",
+        time_to="",
+        key_type="id",
+        pagination=None,
+    )
+    assert "graph" in result
+    assert "direction" in result
+    assert result["direction"] == "upstream"
+
+
+    assert "pagination" in result
+    assert result["pagination"] == {
+            "cursor": 123,
+            "request_id": "123",
+            "has_more": True,
+            "batch_size": 1000,
+        }
+    filtered_graph = result["graph"]
+    assert len(filtered_graph) == 6  # Only table nodes should remain
+    assert all(node["otype"] == "table" for node in filtered_graph)
+    assert filtered_graph[0]["id"] == graph_nodes[0]["id"]
+    assert filtered_graph[1]["id"] == graph_nodes[1]["id"]
+    assert filtered_graph[2]["id"] == graph_nodes[3]["id"]
+    assert filtered_graph[3]["id"] == graph_nodes[4]["id"]
+    assert filtered_graph[4]["id"] == graph_nodes[5]["id"]
+    assert filtered_graph[5]["id"] == graph_nodes[9]["id"]
+
+def test_get_bulk_lineage_success_chunked(alation_api, mock_requests_post, mock_token_methods):
+    graph_nodes = [
+      {"id": 1, "otype": "table", "fully_qualified_name": "1", "neighbors": [{"id": 2, "otype": "table", "fully_qualified_name": "2"}]},
+      {"id": 2, "otype": "table", "fully_qualified_name": "2", "neighbors": [{"id": 3, "otype": "etl", "fully_qualified_name": "3"}, {"id": 4, "otype": "table", "fully_qualified_name": "4"}]},
+      {"id": 3, "otype": "etl", "fully_qualified_name": "3", "neighbors": [{"id": 5, "otype": "table", "fully_qualified_name": "5"}]},
+      {"id": 4, "otype": "table", "fully_qualified_name": "4", "neighbors": []},
+      {"id": 5, "otype": "table", "fully_qualified_name": "5", "neighbors": []},
+      {"id": 6, "otype": "table", "fully_qualified_name": "6", "neighbors": [{"id": 3, "otype": "etl", "fully_qualified_name": "3"}]},
+      {"id": 7, "otype": "etl", "fully_qualified_name": "7", "neighbors": [{"id": 8, "otype": "etl", "fully_qualified_name": "8"}]},
+      {"id": 8, "otype": "etl", "fully_qualified_name": "8", "neighbors": []},
+      {"id": 9, "otype": "etl", "fully_qualified_name": "9", "neighbors": [{"id": 10, "otype": "table", "fully_qualified_name": "10"}]},
+      {"id": 10, "otype": "table", "fully_qualified_name": "10", "neighbors": []}
+    ]
+    mock_requests_post(
+        "/bulk_lineage",
+        response_json=
+            {
+                "graph": graph_nodes,
+                "direction": "upstream",
+                "request_id": "123",
+            },
+        status_code=200,
+    )
+    result = alation_api.get_bulk_lineage(
+        root_nodes=[{"id": 1, "otype": "table"}],
+        direction="upstream",
+        limit=1000,
+        batch_size=1000,
+        processing_mode=LineageGraphProcessingOptions.CHUNKED,
+        show_temporal_objects=False,
+        design_time=LineageDesignTimeOptions.EITHER_DESIGN_OR_RUN_TIME,
+        max_depth=10,
+        allowed_schema_ids=None,
+        allowed_otypes=None,
+        time_from="",
+        time_to="",
+        key_type="id",
+        pagination={
+            "cursor": 123,
+            "request_id": "123",
+            "has_more": True,
+            "batch_size": 1000,
+        },
+    )
+    assert "graph" in result
+    assert "direction" in result
+    assert result["direction"] == "upstream"
+
+    chunked_graph = result["graph"]
+
+    assert "pagination" not in result
+    assert len(chunked_graph) == len(graph_nodes)
+    assert chunked_graph[0]["id"] == graph_nodes[0]["id"]
+    assert chunked_graph[1]["id"] == graph_nodes[1]["id"]
+    assert chunked_graph[2]["id"] == graph_nodes[2]["id"]
+    assert chunked_graph[3]["id"] == graph_nodes[3]["id"]
+    assert chunked_graph[4]["id"] == graph_nodes[4]["id"]
+    assert chunked_graph[5]["id"] == graph_nodes[5]["id"]
+    assert chunked_graph[6]["id"] == graph_nodes[6]["id"]
+    assert chunked_graph[7]["id"] == graph_nodes[7]["id"]
+    assert chunked_graph[8]["id"] == graph_nodes[8]["id"]
+    assert chunked_graph[9]["id"] == graph_nodes[9]["id"]

--- a/python/core-sdk/tests/test_lineage.py
+++ b/python/core-sdk/tests/test_lineage.py
@@ -38,7 +38,6 @@ def test_make_lineage_kwargs_creates_defaults():
     assert response["design_time"] == LineageDesignTimeOptions.EITHER_DESIGN_OR_RUN_TIME
     assert response["max_depth"] == 10
     assert response["excluded_schema_ids"] == []
-    assert response["allowed_otypes"] == []
     assert response["time_from"] == ""
     assert response["time_to"] == ""
     assert response["key_type"] == "id"

--- a/python/core-sdk/tests/test_lineage.py
+++ b/python/core-sdk/tests/test_lineage.py
@@ -405,7 +405,6 @@ def test_alation_lineage_tool_raises_value_errors_during_validation():
             time_to="",
         )
     assert "only supported in 'chunked' processing mode" in str(ex.value)
-        
 
 
 @pytest.fixture

--- a/python/core-sdk/tests/test_lineage.py
+++ b/python/core-sdk/tests/test_lineage.py
@@ -31,7 +31,7 @@ def test_make_lineage_kwargs_creates_defaults():
     assert response["show_temporal_objects"] == False
     assert response["design_time"] == LineageDesignTimeOptions.EITHER_DESIGN_OR_RUN_TIME
     assert response["max_depth"] == 10
-    assert response["allowed_schema_ids"] == []
+    assert response["excluded_schema_ids"] == []
     assert response["allowed_otypes"] == []
     assert response["time_from"] == ""
     assert response["time_to"] == ""
@@ -45,20 +45,20 @@ def test_make_lineage_kwargs_recognizes_fully_qualified_name_as_key_type():
 
 def test_make_lineage_kwargs_respects_provided_values():
     expected_max_depth = 22
-    expected_allowed_schema_ids = [1, 2]
+    expected_excluded_schema_ids = [1, 2]
     expected_allowed_otypes = ["table"]
     expected_processing_mode = LineageGraphProcessingOptions.CHUNKED
     expected_design_time = LineageDesignTimeOptions.ONLY_DESIGN_TIME
     response = make_lineage_kwargs(
       root_node={"id": 1, "otype": "table"},
       max_depth=expected_max_depth,
-      allowed_schema_ids=expected_allowed_schema_ids,
+      excluded_schema_ids=expected_excluded_schema_ids,
       allowed_otypes=expected_allowed_otypes,
       processing_mode=expected_processing_mode,
       design_time=expected_design_time
     )
     assert response["max_depth"] == expected_max_depth
-    assert response["allowed_schema_ids"] == expected_allowed_schema_ids
+    assert response["excluded_schema_ids"] == expected_excluded_schema_ids
     assert response["allowed_otypes"] == expected_allowed_otypes
     assert response["processing_mode"] == expected_processing_mode
     assert response["design_time"] == expected_design_time
@@ -336,7 +336,7 @@ def test_alation_lineage_tool_raises_value_errors_during_validation():
             batch_size=10000,
             processing_mode=LineageGraphProcessingOptions.COMPLETE,
             allowed_otypes=None,
-            allowed_schema_ids=None,
+            excluded_schema_ids=None,
             max_depth=1000,
             show_temporal_objects=False,
             key_type="id",
@@ -354,7 +354,7 @@ def test_alation_lineage_tool_raises_value_errors_during_validation():
             direction="downstream",
             allowed_otypes=[],
             processing_mode=LineageGraphProcessingOptions.COMPLETE,
-            allowed_schema_ids=None,
+            excluded_schema_ids=None,
             max_depth=1000,
             show_temporal_objects=False,
             key_type="id",
@@ -372,7 +372,7 @@ def test_alation_lineage_tool_raises_value_errors_during_validation():
             batch_size=1000,
             allowed_otypes=["table"],
             processing_mode=LineageGraphProcessingOptions.CHUNKED,
-            allowed_schema_ids=None,
+            excluded_schema_ids=None,
             max_depth=1000,
             show_temporal_objects=False,
             key_type="id",
@@ -396,7 +396,7 @@ def test_alation_lineage_tool_raises_value_errors_during_validation():
                 "cursor": 123,
                 "has_more": True
             },
-            allowed_schema_ids=None,
+            excluded_schema_ids=None,
             max_depth=1000,
             show_temporal_objects=False,
             key_type="id",
@@ -503,7 +503,7 @@ def test_get_bulk_lineage_success_complete_filtered_with_pagination_response(ala
         show_temporal_objects=False,
         design_time=LineageDesignTimeOptions.EITHER_DESIGN_OR_RUN_TIME,
         max_depth=10,
-        allowed_schema_ids=None,
+        excluded_schema_ids=None,
         allowed_otypes=["table"],
         time_from="",
         time_to="",
@@ -564,7 +564,7 @@ def test_get_bulk_lineage_success_chunked(alation_api, mock_requests_post, mock_
         show_temporal_objects=False,
         design_time=LineageDesignTimeOptions.EITHER_DESIGN_OR_RUN_TIME,
         max_depth=10,
-        allowed_schema_ids=None,
+        excluded_schema_ids=None,
         allowed_otypes=None,
         time_from="",
         time_to="",

--- a/python/core-sdk/tests/test_sdk.py
+++ b/python/core-sdk/tests/test_sdk.py
@@ -2,7 +2,10 @@ import pytest
 import requests
 from unittest.mock import MagicMock, patch
 
-from alation_ai_agent_sdk.sdk import AlationAIAgentSDK
+from alation_ai_agent_sdk.sdk import (
+    AlationAIAgentSDK,
+    AlationTools,
+)
 from alation_ai_agent_sdk.api import (
     AUTH_METHOD_USER_ACCOUNT,
     AUTH_METHOD_SERVICE_ACCOUNT,
@@ -278,3 +281,21 @@ def test_error_handling_in_token_validation(mock_requests_post):
         with pytest.raises(AlationAPIError, match="Mocked error in JWT token validation"):
             sdk.api._is_jwt_token_valid()
         mock_jwt_token_valid.assert_called_once()
+
+def test_lineage_beta_tools_disabled_by_default():
+    sdk = AlationAIAgentSDK(
+        base_url=MOCK_BASE_URL,
+        auth_method=AUTH_METHOD_USER_ACCOUNT,
+        auth_params=UserAccountAuthParams(MOCK_USER_ID, MOCK_REFRESH_TOKEN),
+    )
+    assert AlationTools.LINEAGE not in sdk.enabled_beta_tools
+
+def test_check_job_status_tool_explicitly_disabled():
+    sdk = AlationAIAgentSDK(
+        base_url=MOCK_BASE_URL,
+        auth_method=AUTH_METHOD_USER_ACCOUNT,
+        auth_params=UserAccountAuthParams(MOCK_USER_ID, MOCK_REFRESH_TOKEN),
+        disabled_tools={AlationTools.CHECK_JOB_STATUS}
+    )
+    assert AlationTools.CHECK_JOB_STATUS in sdk.disabled_tools
+    assert sdk.check_job_status not in sdk.get_tools()

--- a/python/core-sdk/tests/test_sdk.py
+++ b/python/core-sdk/tests/test_sdk.py
@@ -85,6 +85,10 @@ def mock_requests_post(monkeypatch):
         elif "context/" in url:
             if "context/" in mock_post_responses:
                 return mock_post_responses["context/"](*args, **kwargs)
+        elif url in mock_post_responses:
+            return mock_post_responses[url](*args, **kwargs)
+
+        print(f"Unmocked POST URL: {url}")  # Debugging line to see unmocked URLs
 
         # Fallback for unmocked POST requests
         fallback_response = MagicMock(spec=requests.Response)
@@ -315,7 +319,15 @@ def test_error_handling_in_token_validation(mock_requests_post):
             sdk.api._is_jwt_token_valid()
         mock_jwt_token_valid.assert_called_once()
 
-def test_lineage_beta_tools_disabled_by_default():
+def test_lineage_beta_tools_disabled_by_default(
+    mock_requests_get,
+    mock_requests_post,
+):
+    mock_requests_post("createAPIAccessToken", response_json=REFRESH_TOKEN_RESPONSE_SUCCESS)
+    mock_requests_post("oauth/v2/token", response_json=JWT_RESPONSE_SUCCESS)
+    mock_requests_get("license", response_json={"is_cloud": True})
+    mock_requests_get("full_version", response_json={"ALATION_RELEASE_NAME": "2025.1.2"})
+
     sdk = AlationAIAgentSDK(
         base_url=MOCK_BASE_URL,
         auth_method=AUTH_METHOD_USER_ACCOUNT,
@@ -323,7 +335,15 @@ def test_lineage_beta_tools_disabled_by_default():
     )
     assert AlationTools.LINEAGE not in sdk.enabled_beta_tools
 
-def test_check_job_status_tool_explicitly_disabled():
+def test_check_job_status_tool_explicitly_disabled(
+    mock_requests_get,
+    mock_requests_post,
+):
+    mock_requests_post("createAPIAccessToken", response_json=REFRESH_TOKEN_RESPONSE_SUCCESS)
+    mock_requests_post("oauth/v2/token", response_json=JWT_RESPONSE_SUCCESS)
+    mock_requests_get("license", response_json={"is_cloud": True})
+    mock_requests_get("full_version", response_json={"ALATION_RELEASE_NAME": "2025.1.2"})
+
     sdk = AlationAIAgentSDK(
         base_url=MOCK_BASE_URL,
         auth_method=AUTH_METHOD_USER_ACCOUNT,

--- a/python/core-sdk/tests/test_sdk.py
+++ b/python/core-sdk/tests/test_sdk.py
@@ -352,3 +352,4 @@ def test_check_job_status_tool_explicitly_disabled(
     )
     assert AlationTools.CHECK_JOB_STATUS in sdk.disabled_tools
     assert sdk.check_job_status not in sdk.get_tools()
+

--- a/python/core-sdk/tests/test_tools.py
+++ b/python/core-sdk/tests/test_tools.py
@@ -4,11 +4,11 @@ def test_csv_str_to_tool_list():
     """Test conversion of CSV string to tool list."""
     csv_str = "tool1,tool2,tool3"
     expected_tools = ["tool1", "tool2", "tool3"]
-    assert csv_str_to_tool_list(csv_str) == expected_tools
+    assert sorted(csv_str_to_tool_list(csv_str)) == sorted(expected_tools)
 
     # Test with extra spaces
     csv_str_with_spaces = " tool1 , tool2 , tool3 "
-    assert csv_str_to_tool_list(csv_str_with_spaces) == expected_tools
+    assert sorted(csv_str_to_tool_list(csv_str_with_spaces)) == sorted(expected_tools)
 
     # Test with empty string
     assert csv_str_to_tool_list("") == []

--- a/python/core-sdk/tests/test_tools.py
+++ b/python/core-sdk/tests/test_tools.py
@@ -1,0 +1,21 @@
+from alation_ai_agent_sdk.tools import csv_str_to_tool_list
+
+def test_csv_str_to_tool_list():
+    """Test conversion of CSV string to tool list."""
+    csv_str = "tool1,tool2,tool3"
+    expected_tools = ["tool1", "tool2", "tool3"]
+    assert csv_str_to_tool_list(csv_str) == expected_tools
+
+    # Test with extra spaces
+    csv_str_with_spaces = " tool1 , tool2 , tool3 "
+    assert csv_str_to_tool_list(csv_str_with_spaces) == expected_tools
+
+    # Test with empty string
+    assert csv_str_to_tool_list("") == []
+
+    # Test with single tool
+    assert csv_str_to_tool_list("single_tool") == ["single_tool"]
+
+    # Test with duplicate tools
+    csv_str_with_spaces_and_duplicate = " tool1 , tool2 , tool3, tool2"
+    assert sorted(csv_str_to_tool_list(csv_str_with_spaces_and_duplicate)) == sorted(expected_tools)

--- a/python/dist-langchain/alation_ai_agent_langchain/tool.py
+++ b/python/dist-langchain/alation_ai_agent_langchain/tool.py
@@ -123,7 +123,7 @@ def get_check_job_status_tool(sdk: AlationAIAgentSDK) -> StructuredTool:
     )
 
 def get_alation_lineage_tool(sdk: AlationAIAgentSDK) -> StructuredTool:
-    lineage_tool = sdk.get_lineage_tool
+    lineage_tool = sdk.lineage_tool
 
     def run_with_args(
         root_node: LineageRootNode,

--- a/python/dist-langchain/alation_ai_agent_langchain/tool.py
+++ b/python/dist-langchain/alation_ai_agent_langchain/tool.py
@@ -1,6 +1,17 @@
 from typing import Any, Optional
 from alation_ai_agent_sdk import AlationAIAgentSDK
 from alation_ai_agent_sdk.api import CatalogAssetMetadataPayloadItem
+from alation_ai_agent_sdk.lineage import (
+    LineageBatchSizeType,
+    LineageDesignTimeType,
+    LineageDirectionType,
+    LineageExcludedSchemaIdsType,
+    LineageGraphProcessingType,
+    LineageOTypeFilterType,
+    LineagePagination,
+    LineageRootNode,
+    LineageTimestampType,
+)
 from langchain.tools import StructuredTool
 
 
@@ -107,6 +118,47 @@ def get_check_job_status_tool(sdk: AlationAIAgentSDK) -> StructuredTool:
     return StructuredTool.from_function(
         name=check_job_status_tool.name,
         description=check_job_status_tool.description,
+        func=run_with_args,
+        args_schema=None,
+    )
+
+def get_alation_lineage_tool(sdk: AlationAIAgentSDK) -> StructuredTool:
+    lineage_tool = sdk.get_lineage_tool
+
+    def run_with_args(
+        root_node: LineageRootNode,
+        direction: LineageDirectionType,
+        limit: Optional[int] = 1000,
+        batch_size: Optional[LineageBatchSizeType] = 1000,
+        pagination: Optional[LineagePagination] = None,
+        processing_mode: Optional[LineageGraphProcessingType] = None,
+        show_temporal_objects: Optional[bool] = False,
+        design_time: Optional[LineageDesignTimeType] = None,
+        max_depth: Optional[int] = 10,
+        excluded_schema_ids: Optional[LineageExcludedSchemaIdsType] = None,
+        allowed_otypes: Optional[LineageOTypeFilterType] = None,
+        time_from: Optional[LineageTimestampType] = None,
+        time_to: Optional[LineageTimestampType] = None,
+    ):
+        return lineage_tool.run(
+            root_node=root_node,
+            direction=direction,
+            limit=limit,
+            batch_size=batch_size,
+            pagination=pagination,
+            processing_mode=processing_mode,
+            show_temporal_objects=show_temporal_objects,
+            design_time=design_time,
+            max_depth=max_depth,
+            excluded_schema_ids=excluded_schema_ids,
+            allowed_otypes=allowed_otypes,
+            time_from=time_from,
+            time_to=time_to,
+        )
+
+    return StructuredTool.from_function(
+        name=lineage_tool.name,
+        description=lineage_tool.description,
         func=run_with_args,
         args_schema=None,
     )

--- a/python/dist-langchain/alation_ai_agent_langchain/toolkit.py
+++ b/python/dist-langchain/alation_ai_agent_langchain/toolkit.py
@@ -1,4 +1,7 @@
-from alation_ai_agent_sdk import AlationAIAgentSDK
+from alation_ai_agent_sdk import (
+    AlationAIAgentSDK,
+    AlationTools,
+)
 
 from .tool import (
     get_alation_context_tool,
@@ -6,14 +9,22 @@ from .tool import (
     get_alation_data_products_tool,
     get_update_catalog_asset_metadata_tool,
     get_check_job_status_tool,
+    get_alation_lineage_tool,
 )
 
 
 def get_tools(sdk: AlationAIAgentSDK):
-    return [
-        get_update_catalog_asset_metadata_tool(sdk),
-        get_alation_context_tool(sdk),
-        get_alation_bulk_retrieval_tool(sdk),
-        get_alation_data_products_tool(sdk),
-        get_check_job_status_tool(sdk),
-    ]
+    tools = []
+    if sdk.is_tool_enabled(AlationTools.AGGREGATED_CONTEXT):
+        tools.append(get_alation_context_tool(sdk))
+    if sdk.is_tool_enabled(AlationTools.BULK_RETRIEVAL):
+        tools.append(get_alation_bulk_retrieval_tool(sdk))
+    if sdk.is_tool_enabled(AlationTools.DATA_PRODUCT):
+        tools.append(get_alation_data_products_tool(sdk))
+    if sdk.is_tool_enabled(AlationTools.UPDATE_METADATA):
+        tools.append(get_update_catalog_asset_metadata_tool(sdk))
+    if sdk.is_tool_enabled(AlationTools.CHECK_JOB_STATUS):
+        tools.append(get_check_job_status_tool(sdk))
+    if sdk.is_tool_enabled(AlationTools.LINEAGE):
+        tools.append(get_alation_lineage_tool(sdk))
+    return tools

--- a/python/dist-langchain/examples/multi_agent_return_eligibility/schemas.py
+++ b/python/dist-langchain/examples/multi_agent_return_eligibility/schemas.py
@@ -2,7 +2,8 @@
 State definitions and Alation signatures for the minimal customer service agent.
 """
 
-from typing import Dict, List, Optional, TypedDict, Literal, Any
+from typing import Dict, List, Optional, Literal, Any
+from typing_extensions import TypedDict
 
 
 class CustomerState(TypedDict, total=False):

--- a/python/dist-langchain/pdm.lock
+++ b/python/dist-langchain/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:fc78b845d28790f6d7e8db585415f1fe99821ea87686164bb8cdc6eb1de62a14"
+content_hash = "sha256:b5310d82121bfbae8d1e4115fbec3392816a079b2c00170ed527b94bf2271477"
 
 [[metadata.targets]]
 requires_python = ">=3.10"
@@ -775,13 +775,13 @@ files = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.14.0"
+version = "4.14.1"
 requires_python = ">=3.9"
 summary = "Backported and Experimental Type Hints for Python 3.9+"
 groups = ["default"]
 files = [
-    {file = "typing_extensions-4.14.0-py3-none-any.whl", hash = "sha256:a1514509136dd0b477638fc68d6a91497af5076466ad0fa6c338e44e359944af"},
-    {file = "typing_extensions-4.14.0.tar.gz", hash = "sha256:8676b788e32f02ab42d9e7c61324048ae4c6d844a399eebace3d4979d75ceef4"},
+    {file = "typing_extensions-4.14.1-py3-none-any.whl", hash = "sha256:d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76"},
+    {file = "typing_extensions-4.14.1.tar.gz", hash = "sha256:38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36"},
 ]
 
 [[package]]

--- a/python/dist-langchain/pyproject.toml
+++ b/python/dist-langchain/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "alation-ai-agent-langchain"
-version = "0.5.0"
+version = "0.6.0"
 description = "Alation Agent SDK for Langchain"
 dependencies = [
-  "alation-ai-agent-sdk>=0.5.0",
+  "alation-ai-agent-sdk~=0.6.0",
   "requests~=2.32.0",
   "langchain>=0.1.0"
 ]

--- a/python/dist-langchain/pyproject.toml
+++ b/python/dist-langchain/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "alation-ai-agent-langchain"
-version = "0.4.0"
+version = "0.5.0"
 description = "Alation Agent SDK for Langchain"
 dependencies = [
-  "alation-ai-agent-sdk>=0.4.0",
+  "alation-ai-agent-sdk>=0.5.0",
   "requests~=2.32.0",
   "langchain>=0.1.0"
 ]

--- a/python/dist-langchain/tests/test_langchain_integration.py
+++ b/python/dist-langchain/tests/test_langchain_integration.py
@@ -54,9 +54,9 @@ def mock_sdk_with_context_tool():
     mock_sdk.check_job_status_tool.run = MagicMock(
         return_value="Expected check job status via SDK run"
     )
-    mock_sdk.get_lineage_tool = MagicMock()
-    mock_sdk.get_lineage_tool.name = "GetLineageToolFromSDK"
-    mock_sdk.get_lineage_tool.description = (
+    mock_sdk.lineage_tool = MagicMock()
+    mock_sdk.lineage_tool.name = "GetLineageToolFromSDK"
+    mock_sdk.lineage_tool.description = (
         "Provides lineage from SDK"
     )
 
@@ -72,7 +72,7 @@ def mock_sdk_with_context_tool():
 
     """
     def run_with_lineage_tool(*args, **kwargs):
-        return mock_sdk.get_lineage_tool.run(*args, **kwargs)
+        return mock_sdk.lineage_tool.run(*args, **kwargs)
     """
 
     mock_sdk.context_tool.run_with_signature = run_with_signature

--- a/python/dist-langchain/tests/test_langchain_integration.py
+++ b/python/dist-langchain/tests/test_langchain_integration.py
@@ -54,6 +54,11 @@ def mock_sdk_with_context_tool():
     mock_sdk.check_job_status_tool.run = MagicMock(
         return_value="Expected check job status via SDK run"
     )
+    mock_sdk.get_lineage_tool = MagicMock()
+    mock_sdk.get_lineage_tool.name = "GetLineageToolFromSDK"
+    mock_sdk.get_lineage_tool.description = (
+        "Provides lineage from SDK"
+    )
 
     # Patch .run for StructuredTool.func compatibility
     def run_with_signature(*args, **kwargs):
@@ -64,6 +69,11 @@ def mock_sdk_with_context_tool():
 
     def run_with_bulk_signature(*args, **kwargs):
         return mock_sdk.bulk_retrieval_tool.run(*args, **kwargs)
+
+    """
+    def run_with_lineage_tool(*args, **kwargs):
+        return mock_sdk.get_lineage_tool.run(*args, **kwargs)
+    """
 
     mock_sdk.context_tool.run_with_signature = run_with_signature
     mock_sdk.data_product_tool.run_with_query_or_product_id = run_with_query_or_product_id

--- a/python/dist-langchain/tests/test_langchain_integration.py
+++ b/python/dist-langchain/tests/test_langchain_integration.py
@@ -1,17 +1,12 @@
+from alation_ai_agent_sdk.sdk import AlationTools
 import pytest
 from unittest.mock import Mock, MagicMock
 
 from langchain.tools import StructuredTool
-from alation_ai_agent_langchain import get_langchain_tools
+from alation_ai_agent_langchain import UserAccountAuthParams, get_langchain_tools
 from alation_ai_agent_sdk import AlationAIAgentSDK
 
-
-@pytest.fixture
-def mock_sdk_with_context_tool():
-    """
-    Creates a mock AlationAIAgentSDK with a mock context_tool.
-    This mock SDK will be passed to get_langchain_tools.
-    """
+def get_sdk_mock():
     mock_sdk = Mock(spec=AlationAIAgentSDK if "AlationAIAgentSDK" in globals() else object)
 
     mock_sdk.context_tool = MagicMock()
@@ -70,15 +65,22 @@ def mock_sdk_with_context_tool():
     def run_with_bulk_signature(*args, **kwargs):
         return mock_sdk.bulk_retrieval_tool.run(*args, **kwargs)
 
-    """
     def run_with_lineage_tool(*args, **kwargs):
         return mock_sdk.lineage_tool.run(*args, **kwargs)
-    """
 
     mock_sdk.context_tool.run_with_signature = run_with_signature
     mock_sdk.data_product_tool.run_with_query_or_product_id = run_with_query_or_product_id
     mock_sdk.bulk_retrieval_tool.run_with_bulk_signature = run_with_bulk_signature
+    mock_sdk.lineage_tool.run_with_lineage_tool = run_with_lineage_tool
     return mock_sdk
+
+@pytest.fixture
+def mock_sdk_with_context_tool():
+    """
+    Creates a mock AlationAIAgentSDK with a mock context_tool.
+    This mock SDK will be passed to get_langchain_tools.
+    """
+    return get_sdk_mock()
 
 
 def test_get_langchain_tools_returns_list_with_alation_tool(mock_sdk_with_context_tool):
@@ -96,6 +98,38 @@ def test_get_langchain_tools_returns_list_with_alation_tool(mock_sdk_with_contex
         alation_tool, StructuredTool
     ), "The Alation tool in the list should be an instance of StructuredTool."
 
+def test_get_langchain_tools_skips_beta_tools_by_default():
+    sdk = AlationAIAgentSDK(
+        base_url="https://api.alation.com",
+        auth_method="user_account",
+        auth_params=UserAccountAuthParams(
+            user_id=1,
+            refresh_token='blah',
+        ),
+        skip_instance_info=True, # No need to fetch for this test
+    )
+    assert len(sdk.enabled_beta_tools) == 0
+    assert sdk.is_tool_enabled(AlationTools.LINEAGE) is False
+
+    tools_list = get_langchain_tools(sdk)
+    assert all(t.name != AlationTools.LINEAGE for t in tools_list), "Beta tools should be skipped."
+
+def test_get_langchain_tools_skips_disabled_tools():
+    sdk = AlationAIAgentSDK(
+        base_url="https://api.alation.com",
+        auth_method="user_account",
+        auth_params=UserAccountAuthParams(
+            user_id=1,
+            refresh_token='blah',
+        ),
+        disabled_tools=set([AlationTools.AGGREGATED_CONTEXT]),
+        skip_instance_info=True, # No need to fetch for this test
+    )
+    assert len(sdk.disabled_tools) == 1
+    assert sdk.is_tool_enabled(AlationTools.AGGREGATED_CONTEXT) is False
+
+    tools_list = get_langchain_tools(sdk)
+    assert all(t.name != AlationTools.AGGREGATED_CONTEXT for t in tools_list), "Disabled tools should be skipped."
 
 def test_alation_tool_properties_from_list(mock_sdk_with_context_tool):
     """

--- a/python/dist-mcp/README.md
+++ b/python/dist-mcp/README.md
@@ -39,7 +39,7 @@ export ALATION_CLIENT_SECRET="your-client-secret"
 To run the Alation MCP Server, use [uvx](https://docs.astral.sh/uv/guides/tools/) (recommend), use the following command:
 
 ```bash
-uvx --from alation-ai-agent-mcp start-mcp-server
+uvx --from alation-ai-agent-mcp start-alaiton-mcp-server
 ```
 If you prefer to use `pipx`, run the following command:
 ```bash
@@ -51,7 +51,7 @@ pipx run alation-ai-agent-mcp
 2. Run the server:
 ```
 # Option A: Using entry point
-start-mcp-server
+start-alation-mcp-server
 
 # Option B: Using Python module
 python -m alation_ai_agent_mcp

--- a/python/dist-mcp/alation_ai_agent_mcp/server.py
+++ b/python/dist-mcp/alation_ai_agent_mcp/server.py
@@ -30,7 +30,7 @@ logging.basicConfig(
 MCP_SERVER_VERSION = "0.5.0"
 
 
-def create_server(disabled_tools_str: Optional[str], enabled_beta_tools_str: Optional[str]):
+def create_server(disabled_tools_str: Optional[str] = None, enabled_beta_tools_str: Optional[str] = None):
     # Load Alation credentials from environment variables
     base_url = os.getenv("ALATION_BASE_URL")
     auth_method = os.getenv("ALATION_AUTH_METHOD")

--- a/python/dist-mcp/alation_ai_agent_mcp/server.py
+++ b/python/dist-mcp/alation_ai_agent_mcp/server.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 from typing import (
     Any,
@@ -13,18 +14,18 @@ from alation_ai_agent_sdk import (
     AlationTools,
     UserAccountAuthParams,
     ServiceAccountAuthParams,
-    env_to_tool_list,
+    csv_str_to_tool_list,
 )
 from alation_ai_agent_sdk.api import CatalogAssetMetadataPayloadItem
 
 
-def create_server():
+def create_server(disabled_tools_str: Optional[str], enabled_beta_tools_str: Optional[str]):
     # Load Alation credentials from environment variables
     base_url = os.getenv("ALATION_BASE_URL")
     auth_method = os.getenv("ALATION_AUTH_METHOD")
 
-    tools_disabled = env_to_tool_list(os.getenv("ALATION_DISABLED_TOOLS"))
-    beta_tools_enabled = env_to_tool_list(os.getenv("ALATION_ENABLED_BETA_TOOLS"))
+    tools_disabled = csv_str_to_tool_list(disabled_tools_str if disabled_tools_str is not None else os.getenv("ALATION_DISABLED_TOOLS"))
+    beta_tools_enabled = csv_str_to_tool_list(enabled_beta_tools_str if enabled_beta_tools_str is not None else os.getenv("ALATION_ENABLED_BETA_TOOLS"))
 
     if not base_url or not auth_method:
         raise ValueError(
@@ -153,9 +154,14 @@ mcp = None
 
 
 def run_server():
+    parser = argparse.ArgumentParser(description="Alation MCP Server")
+    parser.add_argument("--disabled-tools", type=str, help="Comma-separated list of tools to disable", required=False)
+    parser.add_argument("--enabled-beta-tools", type=str, help="Comma-separated list of beta tools to enable", required=False)
+    args = parser.parse_args()
+
     """Entry point for running the MCP server"""
     global mcp
-    mcp = create_server()
+    mcp = create_server(disabled_tools_str=args.disabled_tools, enabled_beta_tools_str=args.enabled_beta_tools)
     mcp.run()
 
 

--- a/python/dist-mcp/alation_ai_agent_mcp/server.py
+++ b/python/dist-mcp/alation_ai_agent_mcp/server.py
@@ -1,8 +1,20 @@
 import os
-from typing import Dict, Any, Optional
+from typing import (
+    Any,
+    Dict,
+    List,
+    Optional,
+)
 
+from alation_ai_agent_sdk.lineage import LineageBatchSizeType, LineageDesignTimeType, LineageDirectionType, LineageExcludedSchemaIdsType, LineageGraphProcessingType, LineageOTypeFilterType, LineagePagination, LineageRootNode, LineageTimestampType
 from mcp.server.fastmcp import FastMCP
-from alation_ai_agent_sdk import AlationAIAgentSDK, UserAccountAuthParams, ServiceAccountAuthParams
+from alation_ai_agent_sdk import (
+    AlationAIAgentSDK,
+    AlationTools,
+    UserAccountAuthParams,
+    ServiceAccountAuthParams,
+    env_to_tool_list,
+)
 from alation_ai_agent_sdk.api import CatalogAssetMetadataPayloadItem
 
 
@@ -10,6 +22,9 @@ def create_server():
     # Load Alation credentials from environment variables
     base_url = os.getenv("ALATION_BASE_URL")
     auth_method = os.getenv("ALATION_AUTH_METHOD")
+
+    tools_disabled = env_to_tool_list(os.getenv("ALATION_DISABLED_TOOLS"))
+    beta_tools_enabled = env_to_tool_list(os.getenv("ALATION_ENABLED_BETA_TOOLS"))
 
     if not base_url or not auth_method:
         raise ValueError(
@@ -47,46 +62,88 @@ def create_server():
     mcp = FastMCP(name="Alation MCP Server", version="0.4.0")
 
     # Initialize Alation SDK
-    alation_sdk = AlationAIAgentSDK(base_url, auth_method, auth_params)
+    alation_sdk = AlationAIAgentSDK(base_url, auth_method, auth_params, disabled_tools=set(tools_disabled), enabled_beta_tools=set(beta_tools_enabled))
 
-    @mcp.tool(name=alation_sdk.context_tool.name, description=alation_sdk.context_tool.description)
-    def alation_context(question: str, signature: Dict[str, Any] | None = None) -> str:
-        result = alation_sdk.get_context(question, signature)
-        return str(result)
+    if alation_sdk.is_tool_enabled(AlationTools.AGGREGATED_CONTEXT):
+        @mcp.tool(name=alation_sdk.context_tool.name, description=alation_sdk.context_tool.description)
+        def alation_context(question: str, signature: Dict[str, Any] | None = None) -> str:
+            result = alation_sdk.get_context(question, signature)
+            return str(result)
 
-    @mcp.tool(
-        name=alation_sdk.bulk_retrieval_tool.name,
-        description=alation_sdk.bulk_retrieval_tool.description,
-    )
-    def alation_bulk_retrieval(signature: Dict[str, Any]) -> str:
-        result = alation_sdk.get_bulk_objects(signature)
-        return str(result)
+    if alation_sdk.is_tool_enabled(AlationTools.BULK_RETRIEVAL):
+        @mcp.tool(
+            name=alation_sdk.bulk_retrieval_tool.name,
+            description=alation_sdk.bulk_retrieval_tool.description,
+        )
+        def alation_bulk_retrieval(signature: Dict[str, Any]) -> str:
+            result = alation_sdk.get_bulk_objects(signature)
+            return str(result)
 
-    @mcp.tool(
-        name=alation_sdk.data_product_tool.name,
-        description=alation_sdk.data_product_tool.description,
-    )
-    def get_data_products(product_id: Optional[str] = None, query: Optional[str] = None) -> str:
-        result = alation_sdk.get_data_products(product_id, query)
-        return str(result)
+    if alation_sdk.is_tool_enabled(AlationTools.DATA_PRODUCT):
+        @mcp.tool(
+            name=alation_sdk.data_product_tool.name,
+            description=alation_sdk.data_product_tool.description,
+        )
+        def get_data_products(product_id: Optional[str] = None, query: Optional[str] = None) -> str:
+            result = alation_sdk.get_data_products(product_id, query)
+            return str(result)
 
-    @mcp.tool(
-        name=alation_sdk.update_catalog_asset_metadata_tool.name,
-        description=alation_sdk.update_catalog_asset_metadata_tool.description,
-    )
-    def update_catalog_asset_metadata(
-        custom_field_values: list[CatalogAssetMetadataPayloadItem],
-    ) -> str:
-        result = alation_sdk.update_catalog_asset_metadata(custom_field_values)
-        return str(result)
+    if alation_sdk.is_tool_enabled(AlationTools.UPDATE_METADATA):
+        @mcp.tool(
+            name=alation_sdk.update_catalog_asset_metadata_tool.name,
+            description=alation_sdk.update_catalog_asset_metadata_tool.description,
+        )
+        def update_catalog_asset_metadata(
+            custom_field_values: list[CatalogAssetMetadataPayloadItem],
+        ) -> str:
+            result = alation_sdk.update_catalog_asset_metadata(custom_field_values)
+            return str(result)
 
-    @mcp.tool(
-        name=alation_sdk.check_job_status_tool.name,
-        description=alation_sdk.check_job_status_tool.description,
-    )
-    def check_job_status(job_id: int) -> str:
-        result = alation_sdk.check_job_status(job_id)
-        return str(result)
+    if alation_sdk.is_tool_enabled(AlationTools.CHECK_JOB_STATUS):
+        @mcp.tool(
+            name=alation_sdk.check_job_status_tool.name,
+            description=alation_sdk.check_job_status_tool.description,
+        )
+        def check_job_status(job_id: int) -> str:
+            result = alation_sdk.check_job_status(job_id)
+            return str(result)
+
+    if alation_sdk.is_tool_enabled(AlationTools.LINEAGE):
+        @mcp.tool(
+            name=alation_sdk.lineage_tool.name,
+            description=alation_sdk.lineage_tool.description,
+        )
+        def get_lineage(
+            root_node: LineageRootNode,
+            direction: LineageDirectionType,
+            limit: Optional[int] = 1000,
+            batch_size: Optional[LineageBatchSizeType] = 1000,
+            pagination: Optional[LineagePagination] = None,
+            processing_mode: Optional[LineageGraphProcessingType] = None,
+            show_temporal_objects: Optional[bool] = False,
+            design_time: Optional[LineageDesignTimeType] = None,
+            max_depth: Optional[int] = 10,
+            excluded_schema_ids: Optional[LineageExcludedSchemaIdsType] = None,
+            allowed_otypes: Optional[LineageOTypeFilterType] = None,
+            time_from: Optional[LineageTimestampType] = None,
+            time_to: Optional[LineageTimestampType] = None,
+        ) -> str:
+            result = alation_sdk.get_lineage(
+                root_node=root_node,
+                direction=direction,
+                limit=limit,
+                batch_size=batch_size,
+                pagination=pagination,
+                processing_mode=processing_mode,
+                show_temporal_objects=show_temporal_objects,
+                design_time=design_time,
+                max_depth=max_depth,
+                excluded_schema_ids=excluded_schema_ids,
+                allowed_otypes=allowed_otypes,
+                time_from=time_from,
+                time_to=time_to,
+            )
+            return str(result)
 
     return mcp
 

--- a/python/dist-mcp/alation_ai_agent_mcp/server.py
+++ b/python/dist-mcp/alation_ai_agent_mcp/server.py
@@ -186,11 +186,14 @@ def run_server():
     parser = argparse.ArgumentParser(description="Alation MCP Server")
     parser.add_argument("--disabled-tools", type=str, help="Comma-separated list of tools to disable", required=False)
     parser.add_argument("--enabled-beta-tools", type=str, help="Comma-separated list of beta tools to enable", required=False)
-    args = parser.parse_args()
+    args, unknown_args = parser.parse_known_args()
 
     """Entry point for running the MCP server"""
     global mcp
-    mcp = create_server(disabled_tools_str=args.disabled_tools, enabled_beta_tools_str=args.enabled_beta_tools)
+    mcp = create_server(
+        disabled_tools_str=args.disabled_tools if args else None,
+        enabled_beta_tools_str=args.enabled_beta_tools if args else None,
+    )
     mcp.run()
 
 

--- a/python/dist-mcp/alation_ai_agent_mcp/server.py
+++ b/python/dist-mcp/alation_ai_agent_mcp/server.py
@@ -186,7 +186,8 @@ def run_server():
     parser = argparse.ArgumentParser(description="Alation MCP Server")
     parser.add_argument("--disabled-tools", type=str, help="Comma-separated list of tools to disable", required=False)
     parser.add_argument("--enabled-beta-tools", type=str, help="Comma-separated list of beta tools to enable", required=False)
-    args, unknown_args = parser.parse_known_args()
+    # Uses parse_known_args() to prevent exit(2) when there are unknown arguments
+    args = parser.parse_known_args()[0]
 
     """Entry point for running the MCP server"""
     global mcp

--- a/python/dist-mcp/pyproject.toml
+++ b/python/dist-mcp/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "alation-ai-agent-mcp"
-version = "0.4.0"
+version = "0.5.0"
 description = "Alation Agent SDK with MCP support"
 dependencies = [
-  "alation-ai-agent-sdk>=0.4.0",
+  "alation-ai-agent-sdk>=0.5.0",
   "mcp[cli]>=1.2.0",
   "fastMCP>=2.2.6"
 ]

--- a/python/dist-mcp/pyproject.toml
+++ b/python/dist-mcp/pyproject.toml
@@ -35,7 +35,7 @@ dev = [
     "ruff>=0.11.8",
 ]
 [project.scripts]
-"start-mcp-server" = "alation_ai_agent_mcp.server:run_server"
+"start-alation-mcp-server" = "alation_ai_agent_mcp.server:run_server"
 
 [build-system]
 requires = ["pdm-backend"]

--- a/python/dist-mcp/pyproject.toml
+++ b/python/dist-mcp/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "alation-ai-agent-mcp"
-version = "0.5.0"
+version = "0.6.0"
 description = "Alation Agent SDK with MCP support"
 dependencies = [
-  "alation-ai-agent-sdk>=0.5.0",
+  "alation-ai-agent-sdk~=0.6.0",
   "mcp[cli]>=1.2.0",
   "fastMCP>=2.2.6"
 ]

--- a/python/dist-mcp/tests/test_mcp_server.py
+++ b/python/dist-mcp/tests/test_mcp_server.py
@@ -251,3 +251,5 @@ def test_create_server_service_account(
         enabled_beta_tools=set(),
     )
     assert mcp_result is mock_mcp_instance
+
+# TODO: add test for env handling and CLI cases

--- a/python/dist-mcp/tests/test_mcp_server.py
+++ b/python/dist-mcp/tests/test_mcp_server.py
@@ -94,7 +94,7 @@ def test_create_server_success(manage_environment_variables, mock_alation_sdk, m
 
     mock_mcp_class.assert_called_once_with(name="Alation MCP Server", version="0.4.0")
     mock_sdk_class.assert_called_once_with(
-        "https://mock-alation.com", "user_account", UserAccountAuthParams(12345, "mock-token")
+        "https://mock-alation.com", "user_account", UserAccountAuthParams(12345, "mock-token"), disabled_tools=set(), enabled_beta_tools=set()
     )
     assert mcp_result is mock_mcp_instance
 
@@ -205,5 +205,7 @@ def test_create_server_service_account(
         "https://mock-alation.com",
         "service_account",
         ServiceAccountAuthParams("mock-client-id", "mock-client-secret"),
+        disabled_tools=set(),
+        enabled_beta_tools=set(),
     )
     assert mcp_result is mock_mcp_instance

--- a/python/dist-mcp/tests/test_mcp_server.py
+++ b/python/dist-mcp/tests/test_mcp_server.py
@@ -252,4 +252,42 @@ def test_create_server_service_account(
     )
     assert mcp_result is mock_mcp_instance
 
-# TODO: add test for env handling and CLI cases
+@patch("alation_ai_agent_mcp.server.create_server")
+def test_run_server_cli_no_arguments(mock_create_server):
+    with patch("alation_ai_agent_mcp.server.argparse") as mock_argparse:
+        arg_parser = MagicMock()
+        mock_argparse.ArgumentParser.return_value = arg_parser
+        known_args_instance = MagicMock()
+        arg_parser.parse_known_args.return_value = (known_args_instance,)
+        known_args_instance.disabled_tools = None
+        known_args_instance.enabled_beta_tools = None
+
+        server.mcp = None  # Reset global before test
+
+        server.run_server()
+
+        mock_create_server.assert_called_once()
+        mock_create_server.assert_called_with(
+            disabled_tools_str=None,
+            enabled_beta_tools_str=None
+        )
+
+@patch("alation_ai_agent_mcp.server.create_server")
+def test_run_server_cli_with_arguments(mock_create_server):
+    with patch("alation_ai_agent_mcp.server.argparse") as mock_argparse:
+        arg_parser = MagicMock()
+        mock_argparse.ArgumentParser.return_value = arg_parser
+        known_args_instance = MagicMock()
+        arg_parser.parse_known_args.return_value = (known_args_instance,)
+        known_args_instance.disabled_tools = 'tool1,tool2'
+        known_args_instance.enabled_beta_tools = 'tool3'
+
+        server.mcp = None  # Reset global before test
+
+        server.run_server()
+
+        mock_create_server.assert_called_once()
+        mock_create_server.assert_called_with(
+            disabled_tools_str='tool1,tool2',
+            enabled_beta_tools_str='tool3'
+        )

--- a/python/dist-mcp/tests/test_mcp_server.py
+++ b/python/dist-mcp/tests/test_mcp_server.py
@@ -4,7 +4,7 @@ import os
 import pytest
 from unittest.mock import patch, MagicMock
 from alation_ai_agent_mcp import server
-from alation_ai_agent_sdk import UserAccountAuthParams, ServiceAccountAuthParams
+from alation_ai_agent_sdk import AlationTools, UserAccountAuthParams, ServiceAccountAuthParams
 
 
 @pytest.fixture(autouse=True)
@@ -63,6 +63,18 @@ def manage_environment_variables(monkeypatch):
         else:
             monkeypatch.setenv(key, value)
 
+@pytest.fixture()
+def manage_disabled_tools_and_enabled_beta_tools_environment(monkeypatch):
+    """
+    Fixture to set environment variables for disabled tools and enabled beta tools.
+    This is used to test the server creation with specific tool configurations.
+    """
+    monkeypatch.setenv("ALATION_DISABLED_TOOLS", ",".join([AlationTools.AGGREGATED_CONTEXT]))
+    monkeypatch.setenv("ALATION_ENABLED_BETA_TOOLS", ",".join([AlationTools.LINEAGE]))
+    yield
+    monkeypatch.delenv("ALATION_DISABLED_TOOLS", raising=False)
+    monkeypatch.delenv("ALATION_ENABLED_BETA_TOOLS", raising=False)
+
 
 @pytest.fixture
 def mock_alation_sdk():
@@ -86,6 +98,7 @@ def mock_fastmcp():
 
     def mock_tool_decorator(name, description):
         def decorator(func):
+            print("registering MCP tool name:", name)
             mock_mcp_instance.tools[name] = MagicMock(__wrapped__=func)
             mock_mcp_instance.tools[description] = MagicMock(__wrapped__=func)
             return func
@@ -138,6 +151,55 @@ def test_create_server_success(manage_environment_variables, mock_alation_sdk, m
         enabled_beta_tools=set(),
     )
     assert mcp_result is mock_mcp_instance
+
+def test_create_server_disabled_tool_and_enabled_beta_tool(manage_environment_variables, mock_fastmcp):
+    mock_mcp_class, mock_mcp_instance = mock_fastmcp
+
+    mock_mcp_instance.reset_mock()
+
+    mcp_result = server.create_server(disabled_tools_str=AlationTools.AGGREGATED_CONTEXT, enabled_beta_tools_str=AlationTools.LINEAGE)
+
+    mock_mcp_class.assert_called_once_with(name="Alation MCP Server", version=server.MCP_SERVER_VERSION)
+    assert mcp_result is mock_mcp_instance
+    # of 6 possible tools 5 tools are on by default with one 1 beta available
+
+    # So 5, -1 disabled tool, +1 enabled beta tool = 5 total tools
+    assert mock_mcp_instance.tool.call_count == 5
+
+    # NOTE: each distribution may refer to the tools differently. These should be standardized so we can
+    # reuse a set of constants across all projects.
+    assert "alation_context" not in mock_mcp_instance.tools
+
+    assert "bulk_retrieval" in mock_mcp_instance.tools
+    assert "get_data_products" in mock_mcp_instance.tools
+    assert "update_catalog_asset_metadata" in mock_mcp_instance.tools
+    assert "check_job_status" in mock_mcp_instance.tools
+    assert "get_lineage" in mock_mcp_instance.tools
+
+def test_create_server_disabled_tool_and_enabled_beta_tool_via_environment(manage_environment_variables, manage_disabled_tools_and_enabled_beta_tools_environment, mock_fastmcp):
+    mock_mcp_class, mock_mcp_instance = mock_fastmcp
+
+    mock_mcp_instance.reset_mock()
+
+    # The manage fixture is the source of the disbled tools as well as the enabled beta tools
+    mcp_result = server.create_server()
+
+    mock_mcp_class.assert_called_once_with(name="Alation MCP Server", version=server.MCP_SERVER_VERSION)
+    assert mcp_result is mock_mcp_instance
+    # of 6 possible tools 5 tools are on by default with one 1 beta available
+
+    # So 5, -1 disabled tool, +1 enabled beta tool = 5 total tools
+    assert mock_mcp_instance.tool.call_count == 5
+
+    # NOTE: each distribution may refer to the tools differently. These should be standardized so we can
+    # reuse a set of constants across all projects.
+    assert "alation_context" not in mock_mcp_instance.tools
+
+    assert "bulk_retrieval" in mock_mcp_instance.tools
+    assert "get_data_products" in mock_mcp_instance.tools
+    assert "update_catalog_asset_metadata" in mock_mcp_instance.tools
+    assert "check_job_status" in mock_mcp_instance.tools
+    assert "get_lineage" in mock_mcp_instance.tools
 
 
 def test_tool_registration(manage_environment_variables, mock_alation_sdk, mock_fastmcp):


### PR DESCRIPTION
Incorporates a new bulk lineage tool into the SDK. This references the newest public API for Lineage which isn't quite GA.

It is intended to be used on a single root object where it resolves either downstream or upstream lineage.

The returned lineage graph can then be used to help monitor data quality, or perform root cause / impact analysis, or even finding downstream columns for custom field value propagation.