### PR TITLE
AL-199489 alation-ai-sdk returns license warning message

### DIFF
--- a/python/core-sdk/alation_ai_agent_sdk/api.py
+++ b/python/core-sdk/alation_ai_agent_sdk/api.py
@@ -230,7 +230,7 @@ class AlationAPI:
         Returns:
             Union[Dict[str, Any], str]: The formatted response data with entitlement info injected
         """
-        if response.status_code != 200:
+        if not (200 <= response.status_code < 300):
             return response.json()
 
         data = response.json()

--- a/python/core-sdk/alation_ai_agent_sdk/api.py
+++ b/python/core-sdk/alation_ai_agent_sdk/api.py
@@ -56,7 +56,9 @@ class CatalogAssetMetadataPayloadBuilder:
         if missing:
             raise ValueError(f"Missing required fields: {missing}")
         if obj["otype"] not in cls.ALLOWED_OTYPES:
-            raise ValueError(f"Invalid otype: {obj['otype']}. Allowed: {cls.ALLOWED_OTYPES}")
+            raise ValueError(
+                f"Invalid otype: {obj['otype']}. Allowed: {cls.ALLOWED_OTYPES}"
+            )
         if obj["field_id"] not in cls.FIELD_ID_TYPE_MAP:
             raise ValueError(
                 f"Invalid field_id: {obj['field_id']}. Allowed: {list(cls.FIELD_ID_TYPE_MAP.keys())}"
@@ -127,7 +129,9 @@ class AlationAPI:
             self.client_id, self.client_secret = auth_params
 
         else:
-            raise ValueError("auth_method must be either 'user_account' or 'service_account'.")
+            raise ValueError(
+                "auth_method must be either 'user_account' or 'service_account'."
+            )
 
         logger.debug(f"AlationAPI initialized with auth method: {self.auth_method}")
 
@@ -184,8 +188,12 @@ class AlationAPI:
                 dist_version=dist_version,
             )
 
-        status_code = getattr(exception.response, "status_code", HTTPStatus.INTERNAL_SERVER_ERROR)
-        response_text = getattr(exception.response, "text", "No response received from server")
+        status_code = getattr(
+            exception.response, "status_code", HTTPStatus.INTERNAL_SERVER_ERROR
+        )
+        response_text = getattr(
+            exception.response, "text", "No response received from server"
+        )
         if exception.response is not None:
             try:
                 parsed = exception.response.json()
@@ -204,7 +212,34 @@ class AlationAPI:
             help_links=meta["help_links"],
             alation_release_name=alation_release_name,
             dist_version=dist_version,
+            is_retryable=meta.get("is_retryable"),
         )
+
+    def _format_successful_response(
+        self, response: requests.Response
+    ) -> Union[Dict[str, Any], str]:
+        """
+        Format a successful response from the Alation API.
+        Returns:
+            Union[Dict[str, Any], str]: The formatted response data
+        """
+        if response.status_code != 200:
+            return response.json()
+
+        headers = {}
+        if "X-Entitlement-Limit" in response.headers:
+            headers["X-Entitlement-Limit"] = response.headers["X-Entitlement-Limit"]
+        if "X-Entitlement-Usage" in response.headers:
+            headers["X-Entitlement-Usage"] = response.headers["X-Entitlement-Usage"]
+        if "X-Entitlement-Warning" in response.headers:
+            headers["X-Entitlement-Warning"] = response.headers["X-Entitlement-Warning"]
+        meta = {}
+        if headers:
+            meta["headers"] = headers
+        # This is backward incompatible change because it changes the response format.
+        # Alternatively I can inject the "meta" field into the response data itself
+        # data = response.json(); data["meta"] = meta; return data
+        return {"data": response.json(), "meta": meta}
 
     def _generate_access_token_with_refresh_token(self):
         """
@@ -216,7 +251,9 @@ class AlationAPI:
             "user_id": self.user_id,
             "refresh_token": self.refresh_token,
         }
-        logger.debug(f"Generating access token using refresh token for user_id: {self.user_id}")
+        logger.debug(
+            f"Generating access token using refresh token for user_id: {self.user_id}"
+        )
 
         try:
             response = requests.post(url, json=payload, timeout=60)
@@ -237,7 +274,9 @@ class AlationAPI:
             )
 
         if data.get("status") == "failed" or "api_access_token" not in data:
-            meta = AlationErrorClassifier.classify_token_error(response.status_code, data)
+            meta = AlationErrorClassifier.classify_token_error(
+                response.status_code, data
+            )
             raise AlationAPIError(
                 f"Logical failure or missing token in access token response from {url}",
                 status_code=response.status_code,
@@ -285,7 +324,9 @@ class AlationAPI:
             )
 
         if "access_token" not in data:
-            meta = AlationErrorClassifier.classify_token_error(response.status_code, data)
+            meta = AlationErrorClassifier.classify_token_error(
+                response.status_code, data
+            )
             raise AlationAPIError(
                 f"Access token missing in JWT API response from {url}",
                 status_code=response.status_code,
@@ -302,7 +343,9 @@ class AlationAPI:
 
     def _generate_new_token(self):
 
-        logger.info("Access token is invalid or expired. Attempting to generate a new one.")
+        logger.info(
+            "Access token is invalid or expired. Attempting to generate a new one."
+        )
         if self.auth_method == AUTH_METHOD_USER_ACCOUNT:
             self._generate_access_token_with_refresh_token()
         elif self.auth_method == AUTH_METHOD_SERVICE_ACCOUNT:
@@ -329,12 +372,16 @@ class AlationAPI:
             response = requests.post(url, json=payload, headers=headers, timeout=60)
             response.raise_for_status()
         except requests.RequestException as e:
-            status_code = getattr(e.response, "status_code", HTTPStatus.INTERNAL_SERVER_ERROR)
+            status_code = getattr(
+                e.response, "status_code", HTTPStatus.INTERNAL_SERVER_ERROR
+            )
 
             if status_code is HTTPStatus.UNAUTHORIZED:
                 return False
 
-            response_text = getattr(e.response, "text", "No response received from server")
+            response_text = getattr(
+                e.response, "text", "No response received from server"
+            )
             parsed = {"error": response_text}
             meta = AlationErrorClassifier.classify_token_error(status_code, parsed)
 
@@ -382,8 +429,12 @@ class AlationAPI:
             data = response.json()
             return data.get("active", False)
         except requests.RequestException as e:
-            status_code = getattr(e.response, "status_code", HTTPStatus.INTERNAL_SERVER_ERROR)
-            response_text = getattr(e.response, "text", "No response received from server")
+            status_code = getattr(
+                e.response, "status_code", HTTPStatus.INTERNAL_SERVER_ERROR
+            )
+            response_text = getattr(
+                e.response, "text", "No response received from server"
+            )
             parsed = {"error": response_text}
             meta = AlationErrorClassifier.classify_token_error(status_code, parsed)
 
@@ -429,7 +480,9 @@ class AlationAPI:
 
         self._generate_new_token()
 
-    def get_context_from_catalog(self, query: str, signature: Optional[Dict[str, Any]] = None):
+    def get_context_from_catalog(
+        self, query: str, signature: Optional[Dict[str, Any]] = None
+    ):
         """
         Retrieve contextual information from the Alation catalog based on a natural language query and signature.
         """
@@ -458,7 +511,7 @@ class AlationAPI:
             self._handle_request_error(e, "catalog search")
 
         try:
-            return response.json()
+            return self._format_successful_response(response)
         except ValueError:
             raise AlationAPIError(
                 message="Invalid JSON in catalog response",
@@ -484,7 +537,10 @@ class AlationAPI:
             "Accept": "application/json",
         }
 
-        params = {"mode": "bulk", "signature": json.dumps(signature, separators=(",", ":"))}
+        params = {
+            "mode": "bulk",
+            "signature": json.dumps(signature, separators=(",", ":")),
+        }
 
         encoded_params = urllib.parse.urlencode(params, quote_via=urllib.parse.quote)
         url = f"{self.base_url}/integration/v2/context/?{encoded_params}"
@@ -497,7 +553,7 @@ class AlationAPI:
             self._handle_request_error(e, "bulk catalog retrieval")
 
         try:
-            return response.json()
+            return self._format_successful_response(response)
         except ValueError:
             raise AlationAPIError(
                 message="Invalid JSON in bulk catalog response",
@@ -505,7 +561,9 @@ class AlationAPI:
                 response_body=response.text,
                 reason="Malformed Response",
                 resolution_hint="The server returned a non-JSON response. Contact support if this persists.",
-                help_links=["https://developer.alation.com/dev/reference/getaggregatedcontext"],
+                help_links=[
+                    "https://developer.alation.com/dev/reference/getaggregatedcontext"
+                ],
             )
 
     def _fetch_marketplace_id(self, headers: Dict[str, str]) -> str:
@@ -568,7 +626,9 @@ class AlationAPI:
                     "results": [],
                 }
             except requests.RequestException as e:
-                self._handle_request_error(e, f"fetching data product by id: {product_id}")
+                self._handle_request_error(
+                    e, f"fetching data product by id: {product_id}"
+                )
 
         elif query:
             # Fetch marketplace ID if not cached
@@ -592,10 +652,12 @@ class AlationAPI:
                     results = [
                         {
                             "id": product["product"]["product_id"],
-                            "name": product["product"]["spec_json"]["product"]["en"]["name"],
-                            "description": product["product"]["spec_json"]["product"]["en"][
-                                "description"
+                            "name": product["product"]["spec_json"]["product"]["en"][
+                                "name"
                             ],
+                            "description": product["product"]["spec_json"]["product"][
+                                "en"
+                            ]["description"],
                             "url": f"{self.base_url}/app/marketplace/{self.marketplace_id}/data-product/{product['product']['product_id']}/",
                         }
                         for product in response_data
@@ -606,7 +668,9 @@ class AlationAPI:
                     "results": [],
                 }
             except requests.RequestException as e:
-                self._handle_request_error(e, f"searching data products with query: {query}")
+                self._handle_request_error(
+                    e, f"searching data products with query: {query}"
+                )
 
         else:
             raise ValueError(
@@ -662,11 +726,18 @@ class AlationAPI:
             raise ValueError("limit cannot exceed 1,000.")
         if allowed_otypes is not None:
             if processing_mode != LineageGraphProcessingOptions.COMPLETE:
-                raise ValueError("allowed_otypes is only supported in 'complete' processing mode.")
+                raise ValueError(
+                    "allowed_otypes is only supported in 'complete' processing mode."
+                )
             if len(allowed_otypes) == 0:
                 raise ValueError("allowed_otypes cannot be empty list.")
-        if pagination is not None and processing_mode == LineageGraphProcessingOptions.COMPLETE:
-            raise ValueError("pagination is only supported in 'chunked' processing mode.")
+        if (
+            pagination is not None
+            and processing_mode == LineageGraphProcessingOptions.COMPLETE
+        ):
+            raise ValueError(
+                "pagination is only supported in 'chunked' processing mode."
+            )
 
         self._with_valid_token()
 
@@ -701,7 +772,9 @@ class AlationAPI:
             lineage_request_dict["filters"]["temp_filter"] = show_temporal_objects
         url = f"{self.base_url}/integration/v2/bulk_lineage/"
         try:
-            response = requests.post(url, headers=headers, json=lineage_request_dict, timeout=60)
+            response = requests.post(
+                url, headers=headers, json=lineage_request_dict, timeout=60
+            )
             response.raise_for_status()
             response_data = response.json()
             if (
@@ -741,7 +814,9 @@ class AlationAPI:
         Updates metadata for one or more Alation catalog assets via custom field values.
         Validates payload before sending to API.
         """
-        validated_payload = CatalogAssetMetadataPayloadBuilder.build(custom_field_values)
+        validated_payload = CatalogAssetMetadataPayloadBuilder.build(
+            custom_field_values
+        )
         self._with_valid_token()
         headers = {
             "Token": self.access_token,
@@ -750,7 +825,9 @@ class AlationAPI:
         }
         url = f"{self.base_url}/integration/v2/custom_field_value/async/"
         try:
-            response = requests.put(url, headers=headers, json=validated_payload, timeout=60)
+            response = requests.put(
+                url, headers=headers, json=validated_payload, timeout=60
+            )
             response.raise_for_status()
             return response.json()
         except requests.RequestException as e:

--- a/python/core-sdk/alation_ai_agent_sdk/api.py
+++ b/python/core-sdk/alation_ai_agent_sdk/api.py
@@ -227,11 +227,10 @@ class AlationAPI:
             return response.json()
 
         headers = {}
-        if "X-Entitlement-Limit" in response.headers:
-            headers["X-Entitlement-Limit"] = response.headers["X-Entitlement-Limit"]
-        if "X-Entitlement-Usage" in response.headers:
-            headers["X-Entitlement-Usage"] = response.headers["X-Entitlement-Usage"]
         if "X-Entitlement-Warning" in response.headers:
+            # Only include the limit and usage when the warning is issued.
+            headers["X-Entitlement-Limit"] = response.headers["X-Entitlement-Limit"]
+            headers["X-Entitlement-Usage"] = response.headers["X-Entitlement-Usage"]
             headers["X-Entitlement-Warning"] = response.headers["X-Entitlement-Warning"]
         meta = {}
         if headers:

--- a/python/core-sdk/alation_ai_agent_sdk/errors.py
+++ b/python/core-sdk/alation_ai_agent_sdk/errors.py
@@ -100,7 +100,7 @@ class AlationErrorClassifier:
                 "https://developer.alation.com/dev/docs/guide-to-aggregated-context-api-beta"
             ]
         elif status_code == HTTPStatus.TOO_MANY_REQUESTS:
-            if "entitlement" in response_body.get("error", "").lower():
+            if AlationErrorClassifier._is_quota_error(status_code, response_body):
                 reason = "License Quota Exceeded"
                 resolution_hint = (
                     "Quota exhausted. Contact your Account Manager for pricing options."
@@ -163,3 +163,11 @@ class AlationErrorClassifier:
             "resolution_hint": resolution_hint,
             "help_links": help_links,
         }
+
+    @staticmethod
+    def _is_quota_error(status_code: int, response_body: dict) -> bool:
+        """Check if the error is related to quota limits."""
+        return (
+            status_code == HTTPStatus.TOO_MANY_REQUESTS
+            and "entitlement" in response_body.get("error", "").lower()
+        )

--- a/python/core-sdk/alation_ai_agent_sdk/errors.py
+++ b/python/core-sdk/alation_ai_agent_sdk/errors.py
@@ -27,9 +27,8 @@ class AlationAPIError(Exception):
         self.help_links = help_links or []
         self.alation_release_name = alation_release_name
         self.dist_version = dist_version
-        if is_retryable is not None:
-            self.is_retryable = is_retryable
-        else:
+        self.is_retryable = is_retryable
+        if self.is_retryable is None and status_code is not None:
             self.is_retryable = status_code in [
                 HTTPStatus.TOO_MANY_REQUESTS,
                 HTTPStatus.INTERNAL_SERVER_ERROR,

--- a/python/core-sdk/alation_ai_agent_sdk/errors.py
+++ b/python/core-sdk/alation_ai_agent_sdk/errors.py
@@ -16,6 +16,7 @@ class AlationAPIError(Exception):
         help_links=None,
         alation_release_name=None,
         dist_version=None,
+        is_retryable=None,
     ):
         super().__init__(message)
         self.original_exception = original_exception
@@ -26,6 +27,13 @@ class AlationAPIError(Exception):
         self.help_links = help_links or []
         self.alation_release_name = alation_release_name
         self.dist_version = dist_version
+        if is_retryable is not None:
+            self.is_retryable = is_retryable
+        else:
+            self.is_retryable = status_code in [
+                HTTPStatus.TOO_MANY_REQUESTS,
+                HTTPStatus.INTERNAL_SERVER_ERROR,
+            ]
 
     def to_dict(self) -> dict:
         return {
@@ -33,11 +41,7 @@ class AlationAPIError(Exception):
             "status_code": self.status_code,
             "reason": self.reason,
             "resolution_hint": self.resolution_hint,
-            "is_retryable": self.status_code
-            in [
-                HTTPStatus.TOO_MANY_REQUESTS,
-                HTTPStatus.INTERNAL_SERVER_ERROR,
-            ],
+            "is_retryable": self.is_retryable,
             "response_body": self.response_body,
             "help_links": self.help_links,
             "alation_release_name": self.alation_release_name,
@@ -63,6 +67,7 @@ class AlationErrorClassifier:
         reason = "Unexpected Error"
         resolution_hint = "An unknown error occurred."
         help_links = []
+        is_retryable = None
 
         if status_code == HTTPStatus.BAD_REQUEST:
             reason = "Bad Request"
@@ -84,27 +89,36 @@ class AlationErrorClassifier:
             ]
         elif status_code == HTTPStatus.FORBIDDEN:
             reason = "Forbidden"
-            resolution_hint = (
-                "Token likely expired or lacks permissions. Ask the user to re-authenticate."
-            )
+            resolution_hint = "Token likely expired or lacks permissions. Ask the user to re-authenticate."
             help_links = [
                 "https://developer.alation.com/dev/v2024.1/docs/authentication-into-alation-apis",
                 "https://developer.alation.com/dev/reference/refresh-access-token-overview",
             ]
         elif status_code == HTTPStatus.NOT_FOUND:
             reason = "Not Found"
-            resolution_hint = (
-                "The requested resource was not found or is not enabled, check feature flag"
-            )
+            resolution_hint = "The requested resource was not found or is not enabled, check feature flag."
             help_links = [
                 "https://developer.alation.com/dev/docs/guide-to-aggregated-context-api-beta"
             ]
         elif status_code == HTTPStatus.TOO_MANY_REQUESTS:
-            reason = "Too Many Requests"
-            resolution_hint = "Rate limit exceeded. Retry after some time."
-            help_links = [
-                "https://developer.alation.com/dev/docs/guide-to-aggregated-context-api-beta#rate-limiting"
-            ]
+            if "entitlement" in response_body.get("error", "").lower():
+                reason = "License Quota Exceeded"
+                resolution_hint = (
+                    "Quota exhausted. Contact your Account Manager for pricing options."
+                )
+                help_links = [
+                    "https://developer.alation.com/dev/docs/guide-to-aggregated-context-api-beta#overview",
+                ]
+                is_retryable = False
+            else:
+                reason = "Too Many Requests"
+                resolution_hint = (
+                    "Too many requests in a short time. Retry after some time."
+                )
+                help_links = [
+                    "https://developer.alation.com/dev/docs/guide-to-aggregated-context-api-beta#rate-limiting",
+                ]
+                is_retryable = True
         elif status_code == HTTPStatus.INTERNAL_SERVER_ERROR:
             reason = "Internal Server Error"
             resolution_hint = "Server error. Retry later or contact Alation support."
@@ -112,7 +126,12 @@ class AlationErrorClassifier:
                 "https://developer.alation.com/dev/docs/guide-to-aggregated-context-api-beta"
             ]
 
-        return {"reason": reason, "resolution_hint": resolution_hint, "help_links": help_links}
+        return {
+            "reason": reason,
+            "resolution_hint": resolution_hint,
+            "help_links": help_links,
+            "is_retryable": is_retryable,
+        }
 
     @staticmethod
     def classify_token_error(status_code: int, response_body: dict) -> dict:
@@ -125,10 +144,14 @@ class AlationErrorClassifier:
 
         if status_code == HTTPStatus.BAD_REQUEST:
             reason = "Token Request Invalid"
-            resolution_hint = response_body.get("error") or "Token request payload is malformed."
+            resolution_hint = (
+                response_body.get("error") or "Token request payload is malformed."
+            )
         elif status_code == HTTPStatus.UNAUTHORIZED:
             reason = "Token Unauthorized"
-            resolution_hint = "[User ID,refresh token] or [client id, client secret] is invalid."
+            resolution_hint = (
+                "[User ID,refresh token] or [client id, client secret] is invalid."
+            )
         elif status_code == HTTPStatus.FORBIDDEN:
             reason = "Token Forbidden"
             resolution_hint = "You do not have permission to generate a token."
@@ -136,4 +159,8 @@ class AlationErrorClassifier:
             reason = "Token Generation Failed"
             resolution_hint = "Alation server failed to process token request. Retry later or contact Alation support."
 
-        return {"reason": reason, "resolution_hint": resolution_hint, "help_links": help_links}
+        return {
+            "reason": reason,
+            "resolution_hint": resolution_hint,
+            "help_links": help_links,
+        }

--- a/python/core-sdk/tests/test_bulk_retrieval.py
+++ b/python/core-sdk/tests/test_bulk_retrieval.py
@@ -1,7 +1,8 @@
 import pytest
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 from alation_ai_agent_sdk.tools import AlationBulkRetrievalTool
-from alation_ai_agent_sdk.api import AlationAPIError
+from alation_ai_agent_sdk.api import AlationAPI, AlationAPIError
+from alation_ai_agent_sdk.types import ServiceAccountAuthParams
 
 
 @pytest.fixture
@@ -16,6 +17,62 @@ def bulk_retrieval_tool(mock_api):
     return AlationBulkRetrievalTool(mock_api)
 
 
+@pytest.fixture
+def alation_api():
+    """Creates a real AlationAPI instance for testing with HTTP mocking."""
+    api = AlationAPI(
+        base_url="https://test.alation.com",
+        auth_method="service_account",
+        auth_params=ServiceAccountAuthParams("test_client", "test_secret"),
+        skip_instance_info=True,
+    )
+    # Mock the token validation to avoid additional HTTP calls
+    api.access_token = "mock_token"
+    api._token_is_valid_on_server = Mock(return_value=True)
+    return api
+
+
+@pytest.fixture
+def bulk_retrieval_tool_with_alation_api(alation_api):
+    """Creates an AlationBulkRetrievalTool with AlationAPI instance for HTTP-level testing."""
+    return AlationBulkRetrievalTool(alation_api)
+
+
+def create_mock_response(
+    json_data, status_code=200, headers=None, raise_for_status=False
+):
+    """Helper function to create a mock requests.Response object."""
+    mock_response = Mock()
+    mock_response.status_code = status_code
+    mock_response.json.return_value = json_data
+    mock_response.headers = headers or {}
+    mock_response.text = str(json_data)  # Add text attribute for error handling
+
+    if raise_for_status:
+        # Import here to avoid circular imports in test
+        import requests
+
+        http_error = requests.exceptions.HTTPError(f"{status_code} Client Error")
+        http_error.response = mock_response
+        mock_response.raise_for_status.side_effect = http_error
+    else:
+        mock_response.raise_for_status.return_value = None
+
+    return mock_response
+
+
+def create_entitlement_headers(warning=None, limit=None, usage=None):
+    """Helper function to create entitlement headers."""
+    headers = {}
+    if warning:
+        headers["X-Entitlement-Warning"] = warning
+    if limit:
+        headers["X-Entitlement-Limit"] = str(limit)
+    if usage:
+        headers["X-Entitlement-Usage"] = str(usage)
+    return headers
+
+
 def test_bulk_retrieval_tool_run_success(bulk_retrieval_tool, mock_api):
     """Test successful bulk retrieval."""
     # Mock response
@@ -24,17 +81,14 @@ def test_bulk_retrieval_tool_run_success(bulk_retrieval_tool, mock_api):
             {
                 "name": "customers",
                 "description": "Customer data",
-                "url": "https://alation.com/table/123"
+                "url": "https://alation.com/table/123",
             }
         ]
     }
     mock_api.get_bulk_objects_from_catalog.return_value = mock_response
 
     signature = {
-        "table": {
-            "fields_required": ["name", "description", "url"],
-            "limit": 1
-        }
+        "table": {"fields_required": ["name", "description", "url"], "limit": 1}
     }
 
     result = bulk_retrieval_tool.run(signature)
@@ -82,16 +136,11 @@ def test_bulk_retrieval_tool_run_api_error(bulk_retrieval_tool, mock_api):
         message="Bad Request",
         status_code=400,
         reason="Bad Request",
-        resolution_hint="Check signature format"
+        resolution_hint="Check signature format",
     )
     mock_api.get_bulk_objects_from_catalog.side_effect = api_error
 
-    invalid_signature = {
-        "unknown": {
-            "fields_required": ["name"],
-            "limit": 100
-        }
-    }
+    invalid_signature = {"unknown": {"fields_required": ["name"], "limit": 100}}
 
     result = bulk_retrieval_tool.run(invalid_signature)
 
@@ -103,3 +152,130 @@ def test_bulk_retrieval_tool_run_api_error(bulk_retrieval_tool, mock_api):
     assert result["error"]["message"] == "Bad Request"
     assert result["error"]["status_code"] == 400
     assert result["error"]["reason"] == "Bad Request"
+
+
+@patch("alation_ai_agent_sdk.api.requests.get")
+def test_bulk_retrieval_tool_run_usage_quota_warning(
+    mock_requests_get, bulk_retrieval_tool_with_alation_api
+):
+    """Test handling of usage quota warning in the header."""
+    # Mock response data
+    mock_response_data = {
+        "relevant_tables": [
+            {
+                "name": "orders",
+                "description": "Order data",
+                "url": "https://alation.com/table/456",
+            }
+        ]
+    }
+
+    # Create mock response with entitlement headers
+    entitlement_headers = create_entitlement_headers(
+        warning="You are at 94% of your quota. Enforcement starts at 120%.",
+        limit=1000,
+        usage=940,
+    )
+    mock_response = create_mock_response(
+        mock_response_data, headers=entitlement_headers
+    )
+    mock_requests_get.return_value = mock_response
+
+    signature = {
+        "table": {"fields_required": ["name", "description", "url"], "limit": 1}
+    }
+
+    result = bulk_retrieval_tool_with_alation_api.run(signature)
+
+    # Verify the requests.get was called
+    mock_requests_get.assert_called_once()
+
+    # Verify the response data
+    assert "relevant_tables" in result
+    assert len(result["relevant_tables"]) == 1
+    assert result["relevant_tables"][0]["name"] == "orders"
+
+    # Check that the _meta field was injected by _format_successful_response
+    assert "_meta" in result
+    assert "headers" in result["_meta"]
+    assert (
+        result["_meta"]["headers"]["X-Entitlement-Warning"]
+        == "You are at 94% of your quota. Enforcement starts at 120%."
+    )
+    assert result["_meta"]["headers"]["X-Entitlement-Limit"] == "1000"
+    assert result["_meta"]["headers"]["X-Entitlement-Usage"] == "940"
+
+
+@patch("alation_ai_agent_sdk.api.requests.get")
+def test_bulk_retrieval_tool_run_no_entitlement_warning(
+    mock_requests_get, bulk_retrieval_tool_with_alation_api
+):
+    """Test that no entitlement warning does not add _meta field."""
+    # Mock response data without any entitlement headers
+    mock_response_data = {
+        "relevant_tables": [
+            {
+                "name": "customers",
+                "description": "Customer data",
+                "url": "https://alation.com/table/123",
+            }
+        ]
+    }
+
+    # Create mock response without entitlement warning. Only limit and usage
+    entitlement_headers = create_entitlement_headers(
+        limit=1000,
+        usage=1,
+    )
+    mock_response = create_mock_response(
+        mock_response_data, headers=entitlement_headers
+    )
+    mock_requests_get.return_value = mock_response
+
+    signature = {
+        "table": {"fields_required": ["name", "description", "url"], "limit": 1}
+    }
+
+    result = bulk_retrieval_tool_with_alation_api.run(signature)
+
+    # Verify the requests.get was called
+    mock_requests_get.assert_called_once()
+
+    # Verify the response data
+    assert "relevant_tables" in result
+    assert len(result["relevant_tables"]) == 1
+    assert result["relevant_tables"][0]["name"] == "customers"
+
+    # Check that no _meta field was added since there are no entitlement headers
+    assert "_meta" not in result
+
+
+@patch("alation_ai_agent_sdk.api.requests.get")
+def test_bulk_retrieval_tool_with_429_quota_reached(
+    mock_requests_get, bulk_retrieval_tool_with_alation_api
+):
+    """Test that quota exceeded error is handled correctly."""
+    # Mock response data for a 429 Too Many Requests response
+    mock_response_data = {"error": "Entitlement quota exceeded"}
+
+    # Create mock response with 429 status that raises HTTPError
+    mock_response = create_mock_response(
+        mock_response_data, status_code=429, raise_for_status=True
+    )
+    mock_requests_get.return_value = mock_response
+
+    signature = {
+        "table": {"fields_required": ["name", "description", "url"], "limit": 1}
+    }
+
+    result = bulk_retrieval_tool_with_alation_api.run(signature)
+
+    # Verify the requests.get was called
+    mock_requests_get.assert_called_once()
+
+    # Verify that the error was handled by _handle_request_error and returned as an error dict
+    assert "error" in result
+    assert "status_code" in result["error"]
+    assert result["error"]["status_code"] == 429
+    assert result["error"]["reason"] == "License Quota Exceeded"
+    assert result["error"]["is_retryable"] is False

--- a/python/core-sdk/tests/test_bulk_retrieval.py
+++ b/python/core-sdk/tests/test_bulk_retrieval.py
@@ -246,7 +246,7 @@ def test_bulk_retrieval_tool_run_no_entitlement_warning(
     assert len(result["relevant_tables"]) == 1
     assert result["relevant_tables"][0]["name"] == "customers"
 
-    # Check that no _meta field was added since there are no entitlement headers
+    # Check that no _meta field was added since there is no entitlement warning header
     assert "_meta" not in result
 
 


### PR DESCRIPTION
Return license warning message from the api response header. For backward compatibility, the header information is injected to the response data under `_meta` key.
Handle the 429 status code different for quota reached case and rate limit per minute case.